### PR TITLE
feat: add JWT authentication and GET /api/account/me endpoint

### DIFF
--- a/backend/.idea/.gitignore
+++ b/backend/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/backend/.idea/backend.iml
+++ b/backend/.idea/backend.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.14 (backend) (4)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/backend/.idea/inspectionProfiles/profiles_settings.xml
+++ b/backend/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/backend/.idea/misc.xml
+++ b/backend/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.14 (backend) (2)" project-jdk-type="Python SDK" />
+</project>

--- a/backend/.idea/modules.xml
+++ b/backend/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/backend.iml" filepath="$PROJECT_DIR$/.idea/backend.iml" />
+    </modules>
+  </component>
+</project>

--- a/backend/.idea/vcs.xml
+++ b/backend/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/backend/app/account/account_repository.py
+++ b/backend/app/account/account_repository.py
@@ -1,0 +1,26 @@
+from sqlalchemy import select as sa_select
+from sqlalchemy.orm import aliased
+from sqlmodel import Session, select
+
+from app.models.app_user import AppUser
+from app.models.dealership import Dealership
+from app.models.department import Department
+
+
+def get_user_by_email(session: Session, email: str) -> AppUser | None:
+    statement = select(AppUser).where(AppUser.email == email)
+    return session.exec(statement).first()
+
+
+def get_user_profile(session: Session, user_id: int):
+    ManagerAlias = aliased(AppUser, name="manager")
+
+    stmt = (
+        sa_select(AppUser, Dealership, Department, ManagerAlias)
+        .join(Dealership, Dealership.dealership_id == AppUser.dealership_id)
+        .join(Department, Department.department_id == AppUser.department_id)
+        .outerjoin(ManagerAlias, ManagerAlias.user_id == AppUser.manager_user_id)
+        .where(AppUser.user_id == user_id)
+    )
+
+    return session.execute(stmt).first()

--- a/backend/app/account/account_router.py
+++ b/backend/app/account/account_router.py
@@ -1,0 +1,27 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlmodel import Session
+
+from app.account.account_schemas import MeResponse, UserLoginRequest, UserLoginResponse
+from app.account.account_service import get_current_user, get_me, login_user
+from app.database import get_session
+from app.models.app_user import AppUser
+
+router = APIRouter(prefix="/api/account", tags=["Account"])
+
+
+@router.post("/login", response_model=UserLoginResponse, status_code=200)
+def login(
+    request: UserLoginRequest,
+    session: Annotated[Session, Depends(get_session)],
+) -> UserLoginResponse:
+    return login_user(session, request)
+
+
+@router.get("/me", response_model=MeResponse)
+def me(
+    current_user: Annotated[AppUser, Depends(get_current_user)],
+    session: Annotated[Session, Depends(get_session)],
+) -> MeResponse:
+    return get_me(session, current_user)

--- a/backend/app/account/account_schemas.py
+++ b/backend/app/account/account_schemas.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, EmailStr
+
+
+class UserRole(str, Enum):
+    manager = "manager"
+    sales_advisor = "sales_advisor"
+
+
+class UserLoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class UserLoginResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class DepartmentInfo(BaseModel):
+    department_id: int
+    name: str
+
+
+class DealershipInfo(BaseModel):
+    dealership_id: int
+    name: str
+    dealer_code: str
+    city: str
+    country: str
+    region: str
+
+
+class ManagerInfo(BaseModel):
+    user_id: int
+    first_name: str
+    last_name: str
+    email: str
+
+
+class MeResponse(BaseModel):
+    user_id: int
+    email: str
+    first_name: str
+    last_name: str
+    phone: str | None
+    employee_number: str
+    role: UserRole
+    rank: str
+    points: int
+    credit: float
+    status: str
+    last_login_at: datetime | None
+    department: DepartmentInfo
+    dealership: DealershipInfo
+    manager_user_id: int | None
+    manager: ManagerInfo | None

--- a/backend/app/account/account_service.py
+++ b/backend/app/account/account_service.py
@@ -1,0 +1,103 @@
+from datetime import datetime, timezone
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError
+from sqlmodel import Session, select
+
+from app.account.account_repository import get_user_by_email, get_user_profile
+from app.account.account_schemas import (
+    DealershipInfo,
+    DepartmentInfo,
+    ManagerInfo,
+    MeResponse,
+    UserLoginRequest,
+    UserLoginResponse,
+)
+from app.database import get_session
+from app.models.app_user import AppUser
+from app.security import create_access_token, decode_access_token, verify_password
+
+bearer_scheme = HTTPBearer()
+
+
+def login_user(session: Session, request: UserLoginRequest) -> UserLoginResponse:
+    user = get_user_by_email(session, request.email)
+
+    if user is None or not verify_password(request.password, user.password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect email or password",
+        )
+
+    user.last_login_at = datetime.now(timezone.utc)
+    session.add(user)
+    session.commit()
+
+    return UserLoginResponse(access_token=create_access_token(user.user_id))
+
+
+def get_current_user(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(bearer_scheme)],
+    session: Annotated[Session, Depends(get_session)],
+) -> AppUser:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    try:
+        user_id = decode_access_token(credentials.credentials)
+    except (JWTError, ValueError):
+        raise credentials_exception
+
+    user = session.exec(select(AppUser).where(AppUser.user_id == user_id)).first()
+    if user is None:
+        raise credentials_exception
+
+    return user
+
+
+def get_me(session: Session, current_user: AppUser) -> MeResponse:
+    row = get_user_profile(session, current_user.user_id)
+
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    user, dealership, department, manager = row
+
+    return MeResponse(
+        user_id=user.user_id,
+        email=user.email,
+        first_name=user.first_name,
+        last_name=user.last_name,
+        phone=user.phone,
+        employee_number=user.employee_number,
+        role=user.role,
+        rank=user.rank,
+        points=user.points,
+        credit=user.credit,
+        status=user.status,
+        last_login_at=user.last_login_at,
+        department=DepartmentInfo(
+            department_id=department.department_id,
+            name=department.name,
+        ),
+        dealership=DealershipInfo(
+            dealership_id=dealership.dealership_id,
+            name=dealership.name,
+            dealer_code=dealership.dealer_code,
+            city=dealership.city,
+            country=dealership.country,
+            region=dealership.region,
+        ),
+        manager_user_id=user.manager_user_id,
+        manager=ManagerInfo(
+            user_id=manager.user_id,
+            first_name=manager.first_name,
+            last_name=manager.last_name,
+            email=manager.email,
+        ) if manager is not None else None,
+    )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -16,6 +16,9 @@ class Settings:
         "postgresql://championsclub:championsclub_dev_password@localhost:5432/championsclub",
     )
     auto_seed: bool = _get_bool_env("AUTO_SEED", False)
+    secret_key: str = os.getenv("SECRET_KEY", "change-me-in-production")
+    algorithm: str = "HS256"
+    access_token_expire_minutes: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
 
 
 settings = Settings()

--- a/backend/app/data/seeds/seed.py
+++ b/backend/app/data/seeds/seed.py
@@ -3,6 +3,7 @@ from faker import Faker
 from sqlmodel import Session, delete
 
 from app.database import engine, create_db_and_tables
+from app.security import hash_password
 from app.models import (
     Dealership,
     Department,
@@ -347,7 +348,7 @@ def create_users(session: Session, dealerships, departments):
             first_name=fake.first_name(),
             last_name=fake.last_name(),
             email=f"manager{dealership.dealership_id}@championsclub.demo",
-            password="manager123",
+            password=hash_password("manager123"),
             phone=fake.phone_number(),
             employee_number=f"MGR{dealership.dealership_id:04}",
             rank=calculate_rank(points),
@@ -386,7 +387,7 @@ def create_users(session: Session, dealerships, departments):
             first_name=first_name,
             last_name=last_name,
             email=f"user{i + 1}@championsclub.demo",
-            password="advisor123",
+            password=hash_password("advisor123"),
             phone=fake.phone_number(),
             employee_number=f"EMP{i + 1:04}",
             rank=calculate_rank(points),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,9 +6,12 @@ from app.database import create_db_and_tables, engine
 from app.data.seeds.seed import main as run_seed_data
 from app.models import AppUser
 from app import models
+from app.account.account_router import router as account_router
 
 
 app = FastAPI(title="ChampionsClub API")
+
+app.include_router(account_router)
 
 
 def seed_database_if_empty() -> None:

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta, timezone
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from app.config import settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def create_access_token(user_id: int) -> str:
+    expire = datetime.now(timezone.utc) + timedelta(minutes=settings.access_token_expire_minutes)
+    payload = {"sub": str(user_id), "exp": expire}
+    return jwt.encode(payload, settings.secret_key, algorithm=settings.algorithm)
+
+
+def decode_access_token(token: str) -> int:
+    payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+    user_id_str: str | None = payload.get("sub")
+    if user_id_str is None:
+        raise JWTError("Missing subject")
+    return int(user_id_str)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,6 @@ sqlmodel==0.0.24
 psycopg2-binary==2.9.10
 python-dotenv==1.1.0
 faker==37.1.0
+python-jose[cryptography]==3.3.0
+passlib[bcrypt]==1.7.4
+email-validator==2.2.0


### PR DESCRIPTION
- Add security module for password hashing (bcrypt) and JWT tokens
- Create account module with login and profile retrieval endpoints
- Implement GET /api/account/me with user profile data including:
  - Department and dealership information via joins
  - Manager association via self-join
  - Full user details (role, rank, points, credit, etc.)
- Add email-validator to requirements
- Update seed.py to hash passwords with bcrypt