### PR TITLE
[Frontend]: Integrate Manager KPI filters with backend + dynamic KPI loading

### DIFF
--- a/backend/app/manager_statistics/router.py
+++ b/backend/app/manager_statistics/router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from sqlmodel import Session
 
 from app.database import get_session
@@ -24,26 +24,31 @@ def get_current_user(
 
     return user
 
+
 @router.get("/dashboard/users/{user_id}/kpis", response_model=UserKpiResponse)
-def read_user_kpis(
+def read_dashboard_user_kpis(
     user_id: int,
+    interval: str = Query(default="all", pattern="^(day|week|month|all)$"),
     session: Session = Depends(get_session),
     current_user: AppUser = Depends(get_current_user),
 ):
-    return get_user_kpis(session, current_user, user_id)
+    return get_user_kpis(session, current_user, user_id, interval)
+
 
 @router.get("/profile/users/{user_id}/kpis", response_model=UserKpiResponse)
-def read_user_kpis(
+def read_profile_user_kpis(
     user_id: int,
+    interval: str = Query(default="all", pattern="^(day|week|month|all)$"),
     session: Session = Depends(get_session),
     current_user: AppUser = Depends(get_current_user),
 ):
-    return get_user_kpis(session, current_user, user_id)
+    return get_user_kpis(session, current_user, user_id, interval)
 
 
 @router.get("/dashboard/team/kpis", response_model=TeamKpiResponse)
 def read_team_kpis(
+    interval: str = Query(default="all", pattern="^(day|week|month|all)$"),
     session: Session = Depends(get_session),
     current_user: AppUser = Depends(get_current_user),
 ):
-    return get_team_kpis(session, current_user)
+    return get_team_kpis(session, current_user, interval)

--- a/backend/app/manager_statistics/router.py
+++ b/backend/app/manager_statistics/router.py
@@ -3,8 +3,8 @@ from sqlmodel import Session
 
 from app.database import get_session
 from app.models.app_user import AppUser
-from app.manager_statistics.schemas import UserKpiResponse, TeamKpiResponse
-from app.manager_statistics.service import get_user_kpis, get_team_kpis
+from app.manager_statistics.schemas import UserKpiResponse, TeamKpiResponse, ManagedUserResponse
+from app.manager_statistics.service import get_user_kpis, get_team_kpis, get_managed_users
 
 router = APIRouter(prefix="/api/manager", tags=["manager-statistics"])
 
@@ -52,3 +52,10 @@ def read_team_kpis(
     current_user: AppUser = Depends(get_current_user),
 ):
     return get_team_kpis(session, current_user, interval)
+
+@router.get("/dashboard/users", response_model=list[ManagedUserResponse])
+def read_managed_users(
+    session: Session = Depends(get_session),
+    current_user: AppUser = Depends(get_current_user),
+):
+    return get_managed_users(session, current_user)

--- a/backend/app/manager_statistics/schemas.py
+++ b/backend/app/manager_statistics/schemas.py
@@ -38,3 +38,15 @@ class TeamKpisData(BaseModel):
 class TeamKpiResponse(BaseModel):
     manager_id: int
     team_kpis: TeamKpisData
+
+#Modifications for Manager filtering users by team that he manages
+class ManagedUserResponse(BaseModel):
+    user_id: int
+    first_name: str
+    last_name: str
+    email: str
+    role: str
+    current_rank: str
+    total_points: int
+    credit: float
+    status: str

--- a/backend/app/manager_statistics/schemas.py
+++ b/backend/app/manager_statistics/schemas.py
@@ -13,24 +13,28 @@ class UserKpiResponse(BaseModel):
     credit: float
     status: str
 
+    interval: str
     total_transactions: int
     total_sales_amount: float
     total_points_earned: int
     total_products_sold: int
     last_transaction_date: datetime | None
+
 
 class TeamKpisData(BaseModel):
     total_employees: int
     total_points: int
     average_points: float
     total_credit: float
+
+    interval: str
     total_transactions: int
     total_sales_amount: float
     total_points_earned: int
     total_products_sold: int
     last_transaction_date: datetime | None
 
+
 class TeamKpiResponse(BaseModel):
     manager_id: int
     team_kpis: TeamKpisData
-    

--- a/backend/app/manager_statistics/service.py
+++ b/backend/app/manager_statistics/service.py
@@ -6,7 +6,7 @@ from sqlmodel import Session, select, func
 from app.models.app_user import AppUser
 from app.models.sale_transaction import SaleTransaction
 from app.models.sale_transaction_item import SaleTransactionItem
-from app.manager_statistics.schemas import UserKpiResponse, TeamKpiResponse
+from app.manager_statistics.schemas import UserKpiResponse, TeamKpiResponse, ManagedUserResponse
 
 
 def validate_manager(current_user: AppUser):
@@ -173,3 +173,30 @@ def get_team_kpis(
             "last_transaction_date": last_transaction_date,
         },
     }
+
+def get_managed_users(
+    session: Session,
+    current_manager: AppUser,
+) -> list[ManagedUserResponse]:
+    validate_manager(current_manager)
+
+    users = session.exec(
+        select(AppUser)
+        .where(AppUser.manager_user_id == current_manager.user_id)
+        .where(AppUser.role.ilike("sales_advisor"))
+    ).all()
+
+    return [
+        {
+            "user_id": user.user_id,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "email": user.email,
+            "role": user.role,
+            "current_rank": user.rank,
+            "total_points": user.points,
+            "credit": user.credit,
+            "status": user.status,
+        }
+        for user in users
+    ]

--- a/backend/app/manager_statistics/service.py
+++ b/backend/app/manager_statistics/service.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 from fastapi import HTTPException
 from sqlmodel import Session, select, func
 
@@ -12,64 +14,107 @@ def validate_manager(current_user: AppUser):
         raise HTTPException(status_code=403, detail="Access denied: Manager role required")
 
 
-def get_user_kpis(session: Session, current_manager: AppUser, user_id: int) -> UserKpiResponse:
+def get_interval_start_date(interval: str):
+    now = datetime.now(timezone.utc)
+
+    if interval == "all":
+        return None
+
+    if interval == "day":
+        return now - timedelta(days=1)
+
+    if interval == "week":
+        return now - timedelta(weeks=1)
+
+    if interval == "month":
+        return now - timedelta(days=30)
+
+    raise HTTPException(
+        status_code=400,
+        detail="Invalid interval. Use day, week, month, or all.",
+    )
+
+
+def get_user_kpis(
+    session: Session,
+    current_manager: AppUser,
+    user_id: int,
+    interval: str,
+) -> UserKpiResponse:
     validate_manager(current_manager)
 
     target_user = session.get(AppUser, user_id)
 
     if target_user is None or target_user.manager_user_id != current_manager.user_id:
-        raise HTTPException(status_code=404, detail="User not found or not under your management")
-    
+        raise HTTPException(
+            status_code=404,
+            detail="User not found or not under your management",
+        )
+
+    start_date = get_interval_start_date(interval)
+
+    sales_conditions = [SaleTransaction.user_id == user_id]
+
+    if start_date is not None:
+        sales_conditions.append(SaleTransaction.transaction_date >= start_date)
+
     sales_result = session.exec(
         select(
             func.count(SaleTransaction.transaction_id),
             func.coalesce(func.sum(SaleTransaction.amount), 0),
             func.coalesce(func.sum(SaleTransaction.points_earned), 0),
             func.max(SaleTransaction.transaction_date),
-        ).where(SaleTransaction.user_id == user_id)
+        ).where(*sales_conditions)
     ).one()
 
-    total_trascations = sales_result[0]
+    total_transactions = sales_result[0]
     total_sales_amount = sales_result[1]
     total_points_earned = sales_result[2]
     last_transaction_date = sales_result[3]
 
     total_products_sold = session.exec(
         select(func.coalesce(func.sum(SaleTransactionItem.quantity), 0))
-            .join(SaleTransaction,
-                  SaleTransaction.transaction_id == SaleTransactionItem.transaction_id)
-            .where(SaleTransaction.user_id == user_id)
+        .join(
+            SaleTransaction,
+            SaleTransaction.transaction_id == SaleTransactionItem.transaction_id,
+        )
+        .where(*sales_conditions)
     ).one()
 
     return {
         "user_id": target_user.user_id,
         "first_name": target_user.first_name,
-        "last_name": target_user.last_name,   
+        "last_name": target_user.last_name,
         "email": target_user.email,
         "role": target_user.role,
         "current_rank": target_user.rank,
         "total_points": target_user.points,
         "credit": target_user.credit,
         "status": target_user.status,
-        "total_transactions": total_trascations,
+        "interval": interval,
+        "total_transactions": total_transactions,
         "total_sales_amount": total_sales_amount,
         "total_points_earned": total_points_earned,
         "total_products_sold": total_products_sold,
         "last_transaction_date": last_transaction_date,
     }
 
-def get_team_kpis(session: Session, current_manager: AppUser) -> TeamKpiResponse:
 
+def get_team_kpis(
+    session: Session,
+    current_manager: AppUser,
+    interval: str,
+) -> TeamKpiResponse:
     validate_manager(current_manager)
-    
-    # Get all employees managed by the current manager
+
+    start_date = get_interval_start_date(interval)
+
     team_employees = session.exec(
         select(AppUser).where(AppUser.manager_user_id == current_manager.user_id)
     ).all()
-    
+
     total_employees = len(team_employees)
-    
-    # Calculate KPIs from app_user table
+
     user_kpis = session.exec(
         select(
             func.coalesce(func.sum(AppUser.points), 0),
@@ -77,12 +122,16 @@ def get_team_kpis(session: Session, current_manager: AppUser) -> TeamKpiResponse
             func.coalesce(func.sum(AppUser.credit), 0),
         ).where(AppUser.manager_user_id == current_manager.user_id)
     ).one()
-    
+
     total_points = user_kpis[0] or 0
     average_points = user_kpis[1] or 0.0
     total_credit = user_kpis[2] or 0.0
-    
-    # Calculate KPIs from sale_transaction table
+
+    team_sales_conditions = [AppUser.manager_user_id == current_manager.user_id]
+
+    if start_date is not None:
+        team_sales_conditions.append(SaleTransaction.transaction_date >= start_date)
+
     sales_result = session.exec(
         select(
             func.count(SaleTransaction.transaction_id),
@@ -91,7 +140,7 @@ def get_team_kpis(session: Session, current_manager: AppUser) -> TeamKpiResponse
             func.max(SaleTransaction.transaction_date),
         )
         .join(AppUser, AppUser.user_id == SaleTransaction.user_id)
-        .where(AppUser.manager_user_id == current_manager.user_id)
+        .where(*team_sales_conditions)
     ).one()
 
     total_transactions = sales_result[0]
@@ -99,15 +148,14 @@ def get_team_kpis(session: Session, current_manager: AppUser) -> TeamKpiResponse
     total_points_earned = sales_result[2]
     last_transaction_date = sales_result[3]
 
-    # Calculate sold products from sale_transaction_item
     total_products_sold = session.exec(
         select(func.coalesce(func.sum(SaleTransactionItem.quantity), 0))
-            .join(
-                SaleTransaction,
-                SaleTransaction.transaction_id == SaleTransactionItem.transaction_id,
-            )
-            .join(AppUser, AppUser.user_id == SaleTransaction.user_id)
-            .where(AppUser.manager_user_id == current_manager.user_id)
+        .join(
+            SaleTransaction,
+            SaleTransaction.transaction_id == SaleTransactionItem.transaction_id,
+        )
+        .join(AppUser, AppUser.user_id == SaleTransaction.user_id)
+        .where(*team_sales_conditions)
     ).one()
 
     return {
@@ -117,10 +165,11 @@ def get_team_kpis(session: Session, current_manager: AppUser) -> TeamKpiResponse
             "total_points": total_points,
             "average_points": average_points,
             "total_credit": total_credit,
+            "interval": interval,
             "total_transactions": total_transactions,
             "total_sales_amount": total_sales_amount,
             "total_points_earned": total_points_earned,
             "total_products_sold": total_products_sold,
             "last_transaction_date": last_transaction_date,
-        }
+        },
     }

--- a/championsclub-frontend/src/app/layouts/AppShell.tsx
+++ b/championsclub-frontend/src/app/layouts/AppShell.tsx
@@ -7,7 +7,7 @@ type AppShellProps = {
     showTopbar?: boolean;
 };
 
-export default function AppShell({ children, showTopbar = true }: AppShellProps) {
+export default function AppShell({ children, showTopbar = false }: AppShellProps) {
     return (
         <div className="min-h-screen bg-[#060b13] text-slate-100 [background-image:radial-gradient(circle_at_20%_0%,rgba(31,78,121,0.18),transparent_35%),radial-gradient(circle_at_85%_10%,rgba(18,131,177,0.14),transparent_30%)]">
             <div className="flex min-h-screen">

--- a/championsclub-frontend/src/app/layouts/AppShell.tsx
+++ b/championsclub-frontend/src/app/layouts/AppShell.tsx
@@ -4,15 +4,16 @@ import Topbar  from "../../components/layout/Topbar";
 
 type AppShellProps = {
     children: ReactNode;
+    showTopbar?: boolean;
 };
 
-export default function AppShell({ children }: AppShellProps) {
+export default function AppShell({ children, showTopbar = true }: AppShellProps) {
     return (
-        <div className=" min-h-screen bg-slate-100 text-slate-900">
+        <div className="min-h-screen bg-[#060b13] text-slate-100 [background-image:radial-gradient(circle_at_20%_0%,rgba(31,78,121,0.18),transparent_35%),radial-gradient(circle_at_85%_10%,rgba(18,131,177,0.14),transparent_30%)]">
             <div className="flex min-h-screen">
                 <Sidebar />
                 <div className="flex  min-w-0 flex-1 flex-col">
-                    <Topbar />
+                    {showTopbar ? <Topbar /> : null}
                     <main className="flex-1 p-4 md:p-6">
                         <div className="mx-auto w-full max-w-7xl">{children}</div>
                     </main>

--- a/championsclub-frontend/src/components/charts/PerformanceTrendChart.tsx
+++ b/championsclub-frontend/src/components/charts/PerformanceTrendChart.tsx
@@ -28,10 +28,10 @@ export default function PerformanceTrendChart({
   return (
     <Card className="h-[360px]">
       <div className="mb-4">
-        <h3 className="text-lg font-semibold text-slate-900">
+        <h3 className="text-lg font-semibold text-cyan-100">
           Team Performance Trend
         </h3>
-        <p className="text-sm text-slate-500">
+        <p className="text-sm text-slate-400">
           Weekly sales performance compared with target
         </p>
       </div>
@@ -41,27 +41,36 @@ export default function PerformanceTrendChart({
           <AreaChart data={data}>
             <defs>
               <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#0f172a" stopOpacity={0.25} />
-                <stop offset="95%" stopColor="#0f172a" stopOpacity={0.02} />
+                <stop offset="5%" stopColor="#22d3ee" stopOpacity={0.35} />
+                <stop offset="95%" stopColor="#22d3ee" stopOpacity={0.03} />
               </linearGradient>
             </defs>
 
-            <CartesianGrid strokeDasharray="3 3" vertical={false} />
-            <XAxis dataKey="week" />
-            <YAxis />
-            <Tooltip />
+            <CartesianGrid stroke="#23364b" strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="week" tick={{ fill: "#94a3b8", fontSize: 12 }} axisLine={{ stroke: "#28415f" }} tickLine={{ stroke: "#28415f" }} />
+            <YAxis tick={{ fill: "#94a3b8", fontSize: 12 }} axisLine={{ stroke: "#28415f" }} tickLine={{ stroke: "#28415f" }} />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: "#0c192b",
+                border: "1px solid #2b445f",
+                borderRadius: "12px",
+                color: "#e2e8f0",
+              }}
+              itemStyle={{ color: "#cbd5e1" }}
+              labelStyle={{ color: "#67e8f9" }}
+            />
 
             <Area
               type="monotone"
               dataKey="sales"
-              stroke="#0f172a"
+              stroke="#22d3ee"
               fill={`url(#${gradientId})`}
               strokeWidth={3}
             />
             <Line
               type="monotone"
               dataKey="target"
-              stroke="#94a3b8"
+              stroke="#f59e0b"
               strokeWidth={2}
               dot={false}
             />

--- a/championsclub-frontend/src/components/layout/Sidebar.tsx
+++ b/championsclub-frontend/src/components/layout/Sidebar.tsx
@@ -21,12 +21,12 @@ const navItems = [
     
 export default function Sidebar() {
   return (
-    <aside className="sticky top-0 hidden h-screen w-64 shrink-0 self-start border-r border-slate-200 bg-white lg:block">
+    <aside className="sticky top-0 hidden h-screen w-64 shrink-0 self-start border-r border-[#1d2a3a] bg-[#070f1b]/95 backdrop-blur lg:block">
       <div className="flex h-full flex-col justify-between">
         <div className="px-6 py-5">
           <div className="flex flex-col w-fit">
-            <h2 className="text-xl font-bold text-slate-900 w-fit">ChampionsClub</h2>
-            <p className="mt-1 text-sm text-slate-500 w-fit">AI Sales Hub</p>
+            <h2 className="text-xl font-bold text-cyan-100 w-fit">ChampionsClub</h2>
+            <p className="mt-1 text-sm text-slate-400 w-fit">AI Sales Hub</p>
           </div>
 
           <nav className="mt-8 flex flex-col gap-3">
@@ -40,8 +40,8 @@ export default function Sidebar() {
                     [
                       "flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition",
                       isActive
-                        ? "bg-slate-900 text-white shadow-sm"
-                        : "text-slate-600 hover:bg-slate-100 hover:text-slate-900",
+                        ? "border border-cyan-500/40 bg-cyan-500/15 text-cyan-100 shadow-[0_0_22px_rgba(6,182,212,0.18)]"
+                        : "text-slate-300 hover:bg-[#0f1a2a] hover:text-cyan-100",
                     ].join(" ")
                   }
                 >
@@ -53,12 +53,12 @@ export default function Sidebar() {
           </nav>
         </div>
 
-        <div className="border-t border-slate-200 px-6 py-4">
-          <div className="rounded-xl bg-slate-100 p-4">
-            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <div className="border-t border-[#1d2a3a] px-6 py-4">
+          <div className="rounded-xl border border-[#223246] bg-[#0d1624] p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
               Active Role
             </p>
-            <p className="mt-1 text-sm font-semibold text-slate-900">
+            <p className="mt-1 text-sm font-semibold text-cyan-100">
               Manager Demo
             </p>
           </div>

--- a/championsclub-frontend/src/components/layout/Topbar.tsx
+++ b/championsclub-frontend/src/components/layout/Topbar.tsx
@@ -2,25 +2,25 @@ import { Bell } from "lucide-react";
 
 export default function Topbar() {
   return (
-    <header className="border-b border-slate-200 bg-white">
+    <header className="border-b border-[#1d2a3a] bg-[#081120]/85 backdrop-blur">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
         <div>
-          <p className="text-sm text-slate-500">ChampionsClub Platform</p>
-          <h2 className="text-lg font-semibold text-slate-900">
+          <p className="text-sm text-slate-400">ChampionsClub Platform</p>
+          <h2 className="text-lg font-semibold text-cyan-100">
             Performance Management
           </h2>
         </div>
 
         <div className="flex items-center gap-4">
 
-          <button className="relative rounded-full border border-slate-200 p-[clamp(0.5rem,0.7vw,0.8rem)] text-slate-600 transition hover:bg-slate-100">
+          <button className="relative rounded-full border border-[#28415f] bg-[#0d1c30] p-[clamp(0.5rem,0.7vw,0.8rem)] text-cyan-100 transition hover:bg-[#122845]">
             <Bell className="h-[clamp(1rem,1.2vw,1.35rem)] w-[clamp(1rem,1.2vw,1.35rem)]" />
-            <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white">
+            <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-cyan-500 text-[10px] font-bold text-[#031018]">
               3
             </span>
           </button>
 
-          <div className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white">
+          <div className="rounded-xl border border-cyan-500/40 bg-cyan-500/15 px-4 py-2 text-sm font-medium text-cyan-100">
             Manager Demo
           </div>
         </div>

--- a/championsclub-frontend/src/components/layout/Topbar.tsx
+++ b/championsclub-frontend/src/components/layout/Topbar.tsx
@@ -12,10 +12,6 @@ export default function Topbar() {
         </div>
 
         <div className="flex items-center gap-4">
-          <select className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 outline-none">
-            <option>This Week</option>
-            <option>This Month</option>
-          </select>
 
           <button className="relative rounded-full border border-slate-200 p-[clamp(0.5rem,0.7vw,0.8rem)] text-slate-600 transition hover:bg-slate-100">
             <Bell className="h-[clamp(1rem,1.2vw,1.35rem)] w-[clamp(1rem,1.2vw,1.35rem)]" />

--- a/championsclub-frontend/src/components/ui/Card.tsx
+++ b/championsclub-frontend/src/components/ui/Card.tsx
@@ -7,7 +7,7 @@ type CardProps = {
 
 export default function Card({ children, className = "" }: CardProps) {
     return (
-        <div className={`rounded-2xl border border-slate-200 bg-white p-5 shadow-sm ${className}`}>
+        <div className={`rounded-2xl border border-[#1f3045] bg-[#0b1524]/90 p-5 shadow-[0_12px_30px_rgba(2,8,20,0.35)] backdrop-blur ${className}`}>
             {children}
         </div>
     );

--- a/championsclub-frontend/src/features/dashboard/AIExecutiveSummary.tsx
+++ b/championsclub-frontend/src/features/dashboard/AIExecutiveSummary.tsx
@@ -4,15 +4,15 @@ export default function AIExecutiveSummary() {
   return (
     <Card>
       <div className="mb-4">
-        <h3 className="text-lg font-semibold text-slate-900">
+        <h3 className="text-lg font-semibold text-cyan-100">
           AI Executive Summary
         </h3>
-        <p className="text-sm text-slate-500">
+        <p className="text-sm text-slate-400">
           Data-driven highlights for this period
         </p>
       </div>
 
-      <div className="space-y-3 text-sm leading-6 text-slate-700">
+      <div className="space-y-3 text-sm leading-6 text-slate-300">
         <p>
           Team performance remains stable overall, but one dealership is showing
           a decline in financing conversion and may miss its monthly target.

--- a/championsclub-frontend/src/features/dashboard/KPIStatCard.tsx
+++ b/championsclub-frontend/src/features/dashboard/KPIStatCard.tsx
@@ -15,16 +15,16 @@ export default function KPIStatCard({
 }: KPIStatCardProps) {
   const deltaColor =
     status === "positive"
-      ? "text-emerald-600"
+      ? "text-emerald-400"
       : status === "negative"
-      ? "text-red-600"
-      : "text-slate-500";
+      ? "text-rose-400"
+      : "text-slate-400";
 
   return (
     <Card>
-      <p className="text-sm font-medium text-slate-500">{title}</p>
+      <p className="text-sm font-medium text-slate-400">{title}</p>
       <div className="mt-3 flex items-end justify-between">
-        <h3 className="text-3xl font-bold text-slate-900">{value}</h3>
+        <h3 className="text-3xl font-bold text-cyan-100">{value}</h3>
         <span className={`text-sm font-semibold ${deltaColor}`}>{delta}</span>
       </div>
     </Card>

--- a/championsclub-frontend/src/features/dashboard/LeaderboardPreview.tsx
+++ b/championsclub-frontend/src/features/dashboard/LeaderboardPreview.tsx
@@ -18,28 +18,28 @@ export default function LeaderboardPreview({
   return (
     <Card>
       <div className="mb-4">
-        <h3 className="text-lg font-semibold text-slate-900">
+        <h3 className="text-lg font-semibold text-cyan-100">
           Leaderboard Preview
         </h3>
-        <p className="text-sm text-slate-500">Top performing advisors</p>
+        <p className="text-sm text-slate-400">Top performing advisors</p>
       </div>
 
       <div className="space-y-4">
         {items.map((item, index) => (
           <div
             key={item.id}
-            className="flex items-center justify-between rounded-xl border border-slate-200 p-4"
+            className="flex items-center justify-between rounded-xl border border-[#22354d] bg-[#0c192b] p-4"
           >
             <div>
-              <p className="font-semibold text-slate-900">
+              <p className="font-semibold text-slate-100">
                 #{index + 1} {item.name}
               </p>
-              <p className="text-sm text-slate-500">{item.dealership}</p>
+              <p className="text-sm text-slate-400">{item.dealership}</p>
             </div>
 
             <div className="text-right">
-              <p className="font-bold text-slate-900">{item.points} pts</p>
-              <p className="text-sm text-slate-500">{item.tier}</p>
+              <p className="font-bold text-cyan-100">{item.points} pts</p>
+              <p className="text-sm text-slate-400">{item.tier}</p>
             </div>
           </div>
         ))}

--- a/championsclub-frontend/src/features/dashboard/ManagerFilterBar.tsx
+++ b/championsclub-frontend/src/features/dashboard/ManagerFilterBar.tsx
@@ -1,0 +1,98 @@
+// In this file we will create a filter bar that lets us select a user or a team and it shows us the kpi's that are also filtered by time: day, week, month
+type KpiScope = "user" | "team";
+type KpiInterval = "day" | "week" | "month";
+
+type AdvisorOption = {
+  id: number;
+  name: string;
+};
+
+type ManagerKpiFilterBarProps = {
+  scope: KpiScope;
+  interval: KpiInterval;
+  selectedUserId: number | null;
+  advisors: AdvisorOption[];
+  onScopeChange: (scope: KpiScope) => void;
+  onIntervalChange: (interval: KpiInterval) => void;
+  onUserChange: (userId: number) => void;
+};
+
+export default function ManagerKpiFilterBar({
+  scope,
+  interval,
+  selectedUserId,
+  advisors,
+  onScopeChange,
+  onIntervalChange,
+  onUserChange,
+}: ManagerKpiFilterBarProps) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-900">
+            KPI Filters
+          </h3>
+          <p className="mt-1 text-sm text-slate-500">
+            Select whether to view team or advisor performance.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 lg:min-w-[620px]">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-500">
+              Scope
+            </label>
+            <select
+              value={scope}
+              onChange={(event) => onScopeChange(event.target.value as KpiScope)}
+              className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-slate-900"
+            >
+              <option value="team">Team performance</option>
+              <option value="user">Advisor performance</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-500">
+              Advisor
+            </label>
+            <select
+              value={selectedUserId ?? ""}
+              disabled={scope !== "user"}
+              onChange={(event) => onUserChange(Number(event.target.value))}
+              className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400 focus:border-slate-900"
+            >
+              <option value="" disabled>
+                Select advisor
+              </option>
+
+              {advisors.map((advisor) => (
+                <option key={advisor.id} value={advisor.id}>
+                  {advisor.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-500">
+              Interval
+            </label>
+            <select
+              value={interval}
+              onChange={(event) =>
+                onIntervalChange(event.target.value as KpiInterval)
+              }
+              className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-slate-900"
+            >
+              <option value="day">Day</option>
+              <option value="week">Week</option>
+              <option value="month">Month</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/championsclub-frontend/src/features/dashboard/ManagerFilterDrawer.tsx
+++ b/championsclub-frontend/src/features/dashboard/ManagerFilterDrawer.tsx
@@ -1,0 +1,186 @@
+import { ListFilter, X } from "lucide-react";
+import { useState } from "react";
+
+type KpiScope = "user" | "team";
+type KpiInterval = "day" | "week" | "month";
+
+type AdvisorOption = {
+  id: number;
+  name: string;
+};
+
+type ManagerFilterDrawerProps = {
+    scope: KpiScope;
+    interval: KpiInterval;
+    selectedUserId: number | null;
+    advisors: AdvisorOption[];
+    onScopeChange: (scope: KpiScope) => void;
+    onIntervalChange: (interval: KpiInterval) => void;
+    onUserChange: (userId: number) => void;
+};
+
+export default function ManagerFilterDrawer({
+    scope,
+    interval,
+    selectedUserId,
+    advisors,
+    onScopeChange,
+    onIntervalChange,
+    onUserChange,
+}: ManagerFilterDrawerProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const scopeOptions: Array<{ value: KpiScope; label: string }> = [
+      { value: "team", label: "Team performance" },
+      { value: "user", label: "Advisor performance" },
+    ];
+    const intervalOptions: KpiInterval[] = ["day", "week", "month"];
+
+    const optionClass = (active: boolean) =>
+      `rounded-xl border px-3 py-2 text-sm font-medium transition ${
+        active
+          ? "border-cyan-500/50 bg-cyan-500/15 text-cyan-100"
+          : "border-[#29405b] bg-[#0d1a2b] text-slate-200 hover:bg-[#112238]"
+      }`;
+
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => setIsOpen(true)}
+          aria-label="Open filters"
+          className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-cyan-500/40 bg-cyan-500/15 text-cyan-100 shadow-[0_0_18px_rgba(6,182,212,0.18)] transition-all duration-150 hover:bg-cyan-500/20 hover:shadow-[0_0_24px_rgba(6,182,212,0.26)] active:scale-95"
+        >
+          <ListFilter className="h-5 w-5" />
+        </button>
+
+        <div
+          aria-hidden={!isOpen}
+          className={`fixed inset-0 z-50 transition-all duration-300 ${
+            isOpen ? "pointer-events-auto" : "pointer-events-none"
+          }`}
+        >
+          <button
+            type="button"
+            aria-label="Close filters overlay"
+            onClick={() => setIsOpen(false)}
+            className={`absolute inset-0 bg-[#02060d]/70 transition-opacity duration-300 ${
+              isOpen ? "opacity-100" : "opacity-0"
+            }`}
+          />
+
+          <aside
+            className={`absolute right-0 top-0 h-full w-full max-w-sm overflow-y-auto border-l border-[#29405b] bg-[#081322] p-6 shadow-2xl transition-transform duration-300 ease-out ${
+              isOpen ? "translate-x-0" : "translate-x-full"
+            }`}
+          >
+            <div className="mb-6 flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-bold text-cyan-100">Filters</h2>
+                <p className="mt-1 text-sm text-slate-400">
+                  Choose KPI scope and time interval.
+                </p>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="rounded-lg p-2 text-slate-400 transition hover:bg-[#112238] hover:text-cyan-100"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="space-y-8">
+              <section>
+                <p className="mb-3 text-sm font-semibold text-slate-100">
+                  KPI Scope
+                </p>
+
+                <div className="grid grid-cols-1 gap-3" role="group" aria-label="KPI scope">
+                  {scopeOptions.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      aria-pressed={scope === option.value}
+                      onClick={() => onScopeChange(option.value)}
+                      className={optionClass(scope === option.value)}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              </section>
+
+              {scope === "user" ? (
+                <section>
+                  <p className="mb-3 text-sm font-semibold text-slate-100">
+                    Advisor
+                  </p>
+
+                  <div className="grid grid-cols-1 gap-2" role="group" aria-label="Advisor">
+                    {advisors.map((advisor) => (
+                      <button
+                        key={advisor.id}
+                        type="button"
+                        aria-pressed={selectedUserId === advisor.id}
+                        onClick={() => onUserChange(advisor.id)}
+                        className={`rounded-xl border px-3 py-2 text-left text-sm font-medium transition ${
+                          selectedUserId === advisor.id
+                            ? "border-cyan-500/50 bg-cyan-500/15 text-cyan-100"
+                            : "border-[#29405b] bg-[#0d1a2b] text-slate-200 hover:bg-[#112238]"
+                        }`}
+                      >
+                        {advisor.name}
+                      </button>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+
+              <section>
+                <p className="mb-3 text-sm font-semibold text-slate-100">
+                  Time Interval
+                </p>
+
+                <div className="grid grid-cols-3 gap-2" role="group" aria-label="Time interval">
+                  {intervalOptions.map((value) => (
+                    <button
+                      key={value}
+                      type="button"
+                      aria-pressed={interval === value}
+                      onClick={() => onIntervalChange(value)}
+                      className={`${optionClass(interval === value)} capitalize`}
+                    >
+                      {value}
+                    </button>
+                  ))}
+                </div>
+              </section>
+            </div>
+
+            <div className="mt-8 flex gap-3">
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="flex-1 rounded-xl border border-cyan-500/50 bg-cyan-500/20 px-4 py-3 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-500/25"
+              >
+                Apply filters
+              </button>
+
+              <button
+                type="button"
+                onClick={() => {
+                  onScopeChange("team");
+                  onIntervalChange("week");
+                  setIsOpen(false);
+                }}
+                className="rounded-xl border border-[#29405b] bg-[#0d1a2b] px-4 py-3 text-sm font-semibold text-slate-200 transition hover:bg-[#112238]"
+              >
+                Reset
+              </button>
+            </div>
+          </aside>
+        </div>
+      </>
+  );
+}

--- a/championsclub-frontend/src/features/dashboard/ManagerFilterDrawer.tsx
+++ b/championsclub-frontend/src/features/dashboard/ManagerFilterDrawer.tsx
@@ -1,123 +1,132 @@
 import { ListFilter, X } from "lucide-react";
 import { useState } from "react";
-
-type KpiScope = "user" | "team";
-type KpiInterval = "day" | "week" | "month";
-
-type AdvisorOption = {
-  id: number;
-  name: string;
-};
+import type {
+  AdvisorOption,
+  KpiInterval,
+  KpiScope,
+} from "../../services/api/managerStatisticsService";
 
 type ManagerFilterDrawerProps = {
-    scope: KpiScope;
-    interval: KpiInterval;
-    selectedUserId: number | null;
-    advisors: AdvisorOption[];
-    onScopeChange: (scope: KpiScope) => void;
-    onIntervalChange: (interval: KpiInterval) => void;
-    onUserChange: (userId: number) => void;
+  scope: KpiScope;
+  interval: KpiInterval;
+  selectedUserId: number | null;
+  advisors: AdvisorOption[];
+  onScopeChange: (scope: KpiScope) => void;
+  onIntervalChange: (interval: KpiInterval) => void;
+  onUserChange: (userId: number | null) => void;
 };
 
 export default function ManagerFilterDrawer({
-    scope,
-    interval,
-    selectedUserId,
-    advisors,
-    onScopeChange,
-    onIntervalChange,
-    onUserChange,
+  scope,
+  interval,
+  selectedUserId,
+  advisors,
+  onScopeChange,
+  onIntervalChange,
+  onUserChange,
 }: ManagerFilterDrawerProps) {
-    const [isOpen, setIsOpen] = useState(false);
-    const scopeOptions: Array<{ value: KpiScope; label: string }> = [
-      { value: "team", label: "Team performance" },
-      { value: "user", label: "Advisor performance" },
-    ];
-    const intervalOptions: KpiInterval[] = ["day", "week", "month"];
+  const [isOpen, setIsOpen] = useState(false);
 
-    const optionClass = (active: boolean) =>
-      `rounded-xl border px-3 py-2 text-sm font-medium transition ${
-        active
-          ? "border-cyan-500/50 bg-cyan-500/15 text-cyan-100"
-          : "border-[#29405b] bg-[#0d1a2b] text-slate-200 hover:bg-[#112238]"
-      }`;
+  const scopeOptions: Array<{ value: KpiScope; label: string }> = [
+    { value: "team", label: "Team performance" },
+    { value: "user", label: "Advisor performance" },
+  ];
 
-    return (
-      <>
+  const intervalOptions: KpiInterval[] = ["day", "week", "month", "all"];
+
+  const optionClass = (active: boolean) =>
+    `rounded-xl border px-3 py-2 text-sm font-medium transition ${
+      active
+        ? "border-cyan-500/50 bg-cyan-500/15 text-cyan-100"
+        : "border-[#29405b] bg-[#0d1a2b] text-slate-200 hover:bg-[#112238]"
+    }`;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        aria-label="Open filters"
+        className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-cyan-500/40 bg-cyan-500/15 text-cyan-100 shadow-[0_0_18px_rgba(6,182,212,0.18)] transition-all duration-150 hover:bg-cyan-500/20 hover:shadow-[0_0_24px_rgba(6,182,212,0.26)] active:scale-95"
+      >
+        <ListFilter className="h-5 w-5" />
+      </button>
+
+      <div
+        className={`fixed inset-0 z-50 transition-all duration-300 ${
+          isOpen ? "pointer-events-auto" : "pointer-events-none"
+        }`}
+      >
         <button
           type="button"
-          onClick={() => setIsOpen(true)}
-          aria-label="Open filters"
-          className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-cyan-500/40 bg-cyan-500/15 text-cyan-100 shadow-[0_0_18px_rgba(6,182,212,0.18)] transition-all duration-150 hover:bg-cyan-500/20 hover:shadow-[0_0_24px_rgba(6,182,212,0.26)] active:scale-95"
-        >
-          <ListFilter className="h-5 w-5" />
-        </button>
+          aria-label="Close filters overlay"
+          onClick={() => setIsOpen(false)}
+          className={`absolute inset-0 bg-[#02060d]/70 transition-opacity duration-300 ${
+            isOpen ? "opacity-100" : "opacity-0"
+          }`}
+        />
 
-        <div
-          aria-hidden={!isOpen}
-          className={`fixed inset-0 z-50 transition-all duration-300 ${
-            isOpen ? "pointer-events-auto" : "pointer-events-none"
+        <aside
+          className={`absolute right-0 top-0 h-full w-full max-w-sm overflow-y-auto border-l border-[#29405b] bg-[#081322] p-6 shadow-2xl transition-transform duration-300 ease-out ${
+            isOpen ? "translate-x-0" : "translate-x-full"
           }`}
         >
-          <button
-            type="button"
-            aria-label="Close filters overlay"
-            onClick={() => setIsOpen(false)}
-            className={`absolute inset-0 bg-[#02060d]/70 transition-opacity duration-300 ${
-              isOpen ? "opacity-100" : "opacity-0"
-            }`}
-          />
-
-          <aside
-            className={`absolute right-0 top-0 h-full w-full max-w-sm overflow-y-auto border-l border-[#29405b] bg-[#081322] p-6 shadow-2xl transition-transform duration-300 ease-out ${
-              isOpen ? "translate-x-0" : "translate-x-full"
-            }`}
-          >
-            <div className="mb-6 flex items-start justify-between gap-4">
-              <div>
-                <h2 className="text-lg font-bold text-cyan-100">Filters</h2>
-                <p className="mt-1 text-sm text-slate-400">
-                  Choose KPI scope and time interval.
-                </p>
-              </div>
-
-              <button
-                type="button"
-                onClick={() => setIsOpen(false)}
-                className="rounded-lg p-2 text-slate-400 transition hover:bg-[#112238] hover:text-cyan-100"
-              >
-                <X className="h-5 w-5" />
-              </button>
+          <div className="mb-6 flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-lg font-bold text-cyan-100">Filters</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                Choose KPI scope and time interval.
+              </p>
             </div>
 
-            <div className="space-y-8">
+            <button
+              type="button"
+              onClick={() => setIsOpen(false)}
+              className="rounded-lg p-2 text-slate-400 transition hover:bg-[#112238] hover:text-cyan-100"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="space-y-8">
+            <section>
+              <p className="mb-3 text-sm font-semibold text-slate-100">
+                KPI Scope
+              </p>
+
+              <div className="grid grid-cols-1 gap-3">
+                {scopeOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={scope === option.value}
+                    onClick={() => {
+                      onScopeChange(option.value);
+
+                      if (option.value === "team") {
+                        onUserChange(null);
+                      }
+                    }}
+                    className={optionClass(scope === option.value)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </section>
+
+            {scope === "user" && (
               <section>
                 <p className="mb-3 text-sm font-semibold text-slate-100">
-                  KPI Scope
+                  Advisor
                 </p>
 
-                <div className="grid grid-cols-1 gap-3" role="group" aria-label="KPI scope">
-                  {scopeOptions.map((option) => (
-                    <button
-                      key={option.value}
-                      type="button"
-                      aria-pressed={scope === option.value}
-                      onClick={() => onScopeChange(option.value)}
-                      className={optionClass(scope === option.value)}
-                    >
-                      {option.label}
-                    </button>
-                  ))}
-                </div>
-              </section>
-
-              {scope === "user" ? (
-                <section>
-                  <p className="mb-3 text-sm font-semibold text-slate-100">
-                    Advisor
+                {advisors.length === 0 ? (
+                  <p className="rounded-xl border border-[#29405b] bg-[#0d1a2b] px-3 py-2 text-sm text-slate-400">
+                    No advisors available for this manager.
                   </p>
-
-                  <div className="grid grid-cols-1 gap-2" role="group" aria-label="Advisor">
+                ) : (
+                  <div className="grid grid-cols-1 gap-2">
                     {advisors.map((advisor) => (
                       <button
                         key={advisor.id}
@@ -134,53 +143,55 @@ export default function ManagerFilterDrawer({
                       </button>
                     ))}
                   </div>
-                </section>
-              ) : null}
-
-              <section>
-                <p className="mb-3 text-sm font-semibold text-slate-100">
-                  Time Interval
-                </p>
-
-                <div className="grid grid-cols-3 gap-2" role="group" aria-label="Time interval">
-                  {intervalOptions.map((value) => (
-                    <button
-                      key={value}
-                      type="button"
-                      aria-pressed={interval === value}
-                      onClick={() => onIntervalChange(value)}
-                      className={`${optionClass(interval === value)} capitalize`}
-                    >
-                      {value}
-                    </button>
-                  ))}
-                </div>
+                )}
               </section>
-            </div>
+            )}
 
-            <div className="mt-8 flex gap-3">
-              <button
-                type="button"
-                onClick={() => setIsOpen(false)}
-                className="flex-1 rounded-xl border border-cyan-500/50 bg-cyan-500/20 px-4 py-3 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-500/25"
-              >
-                Apply filters
-              </button>
+            <section>
+              <p className="mb-3 text-sm font-semibold text-slate-100">
+                Time Interval
+              </p>
 
-              <button
-                type="button"
-                onClick={() => {
-                  onScopeChange("team");
-                  onIntervalChange("week");
-                  setIsOpen(false);
-                }}
-                className="rounded-xl border border-[#29405b] bg-[#0d1a2b] px-4 py-3 text-sm font-semibold text-slate-200 transition hover:bg-[#112238]"
-              >
-                Reset
-              </button>
-            </div>
-          </aside>
-        </div>
-      </>
+              <div className="grid grid-cols-2 gap-2">
+                {intervalOptions.map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    aria-pressed={interval === value}
+                    onClick={() => onIntervalChange(value)}
+                    className={`${optionClass(interval === value)} capitalize`}
+                  >
+                    {value}
+                  </button>
+                ))}
+              </div>
+            </section>
+          </div>
+
+          <div className="mt-8 flex gap-3">
+            <button
+              type="button"
+              onClick={() => setIsOpen(false)}
+              className="flex-1 rounded-xl border border-cyan-500/50 bg-cyan-500/20 px-4 py-3 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-500/25"
+            >
+              Apply filters
+            </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                onScopeChange("team");
+                onIntervalChange("week");
+                onUserChange(null);
+                setIsOpen(false);
+              }}
+              className="rounded-xl border border-[#29405b] bg-[#0d1a2b] px-4 py-3 text-sm font-semibold text-slate-200 transition hover:bg-[#112238]"
+            >
+              Reset
+            </button>
+          </div>
+        </aside>
+      </div>
+    </>
   );
 }

--- a/championsclub-frontend/src/features/dashboard/PriorityAlertsPanel.tsx
+++ b/championsclub-frontend/src/features/dashboard/PriorityAlertsPanel.tsx
@@ -24,21 +24,21 @@ export default function PriorityAlertsPanel({
 
   const getSeverityClasses = (severity: string) => {
     if (severity === "high") {
-      return "bg-red-100 text-red-700";
+      return "border border-rose-400/30 bg-rose-500/10 text-rose-300";
     }
 
     if (severity === "medium") {
-      return "bg-amber-100 text-amber-700";
+      return "border border-amber-400/30 bg-amber-500/10 text-amber-300";
     }
 
-    return "bg-slate-100 text-slate-700";
+    return "border border-cyan-400/30 bg-cyan-500/10 text-cyan-300";
   };
 
   return (
     <Card className="h-full">
       <div className="mb-4">
-        <h3 className="text-lg font-semibold text-slate-900">Priority Alerts</h3>
-        <p className="text-sm text-slate-500">
+        <h3 className="text-lg font-semibold text-cyan-100">Priority Alerts</h3>
+        <p className="text-sm text-slate-400">
           Issues that require manager attention
         </p>
       </div>
@@ -47,10 +47,10 @@ export default function PriorityAlertsPanel({
         {alerts.map((alert) => (
           <div
             key={alert.id}
-            className="rounded-xl border border-slate-200 p-4"
+            className="rounded-xl border border-[#22354d] bg-[#0c192b] p-4"
           >
             <div className="mb-3 flex items-center justify-between gap-3">
-              <h4 className="font-semibold text-slate-900">{alert.title}</h4>
+              <h4 className="font-semibold text-slate-100">{alert.title}</h4>
               <span
                 className={`rounded-full px-2.5 py-1 text-xs font-semibold ${getSeverityClasses(
                   alert.severity
@@ -60,22 +60,22 @@ export default function PriorityAlertsPanel({
               </span>
             </div>
 
-            <p className="text-sm text-slate-600">{alert.summary}</p>
+            <p className="text-sm text-slate-300">{alert.summary}</p>
 
-            <div className="mt-3 text-sm text-slate-500">
+            <div className="mt-3 text-sm text-slate-400">
               <p>
-                <span className="font-medium text-slate-700">Advisor:</span>{" "}
+                <span className="font-medium text-slate-200">Advisor:</span>{" "}
                 {alert.advisorName}
               </p>
               <p>
-                <span className="font-medium text-slate-700">Dealership:</span>{" "}
+                <span className="font-medium text-slate-200">Dealership:</span>{" "}
                 {alert.dealership}
               </p>
             </div>
 
             <button
               onClick={() => navigate(`/advisor/${alert.advisorId}`)}
-              className="mt-4 text-[clamp(0.9rem,0.9vw,1rem)] font-semibold text-slate-900 transition hover:underline"
+              className="mt-4 text-[clamp(0.9rem,0.9vw,1rem)] font-semibold text-cyan-300 transition hover:text-cyan-200 hover:underline"
             >
               View advisor
             </button>

--- a/championsclub-frontend/src/features/dashboard/kpiMapper.ts
+++ b/championsclub-frontend/src/features/dashboard/kpiMapper.ts
@@ -1,0 +1,73 @@
+import type {
+  TeamKpisData,
+  UserKpiResponse,
+} from "../../services/api/managerStatisticsService";
+
+export type DashboardKpiCard = {
+  title: string;
+  value: string;
+  delta: string;
+  status: "positive" | "negative" | "neutral";
+};
+
+function formatCurrency(value: number) {
+  return `€${Number(value).toLocaleString()}`;
+}
+
+export function mapTeamKpisToCards(kpis: TeamKpisData): DashboardKpiCard[] {
+  return [
+    {
+      title: "Total Employees",
+      value: String(kpis.total_employees),
+      delta: "Managed advisors",
+      status: "neutral",
+    },
+    {
+      title: "Total Points",
+      value: Number(kpis.total_points).toLocaleString(),
+      delta: "Current team points",
+      status: "positive",
+    },
+    {
+      title: "Sales Amount",
+      value: formatCurrency(kpis.total_sales_amount),
+      delta: `${kpis.interval} interval`,
+      status: "positive",
+    },
+    {
+      title: "Products Sold",
+      value: String(kpis.total_products_sold),
+      delta: `${kpis.total_transactions} transactions`,
+      status: "positive",
+    },
+  ];
+}
+
+export function mapUserKpisToCards(kpis: UserKpiResponse): DashboardKpiCard[] {
+  return [
+    {
+      title: "Advisor Points",
+      value: Number(kpis.total_points).toLocaleString(),
+      delta: kpis.current_rank,
+      status: "positive",
+    },
+    {
+      title: "Credit",
+      value: Number(kpis.credit).toLocaleString(),
+      delta: "Redeemable balance",
+      status: "neutral",
+    },
+    {
+      title: "Sales Amount",
+      value: formatCurrency(kpis.total_sales_amount),
+      delta: `${kpis.interval} interval`,
+      status: "positive",
+    },
+    {
+      title: "Products Sold",
+      value: String(kpis.total_products_sold),
+      delta: `${kpis.total_transactions} transactions`,
+      status: "positive",
+    },
+  ];
+}

--- a/championsclub-frontend/src/index.css
+++ b/championsclub-frontend/src/index.css
@@ -1,23 +1,25 @@
-:root {
-  --text: #6b6375;
-  --text-h: #08060d;
-  --bg: #fff;
-  --border: #e5e4e7;
-  --code-bg: #f4f3ec;
-  --accent: #aa3bff;
-  --accent-bg: rgba(170, 59, 255, 0.1);
-  --accent-border: rgba(170, 59, 255, 0.5);
-  --social-bg: rgba(244, 243, 236, 0.5);
-  --shadow:
-    rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
+@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
 
-  --sans: system-ui, 'Segoe UI', Roboto, sans-serif;
-  --heading: system-ui, 'Segoe UI', Roboto, sans-serif;
-  --mono: ui-monospace, Consolas, monospace;
+:root {
+  --text: #cbd5e1;
+  --text-h: #dff7ff;
+  --bg: #060b13;
+  --border: #213147;
+  --code-bg: #0d1624;
+  --accent: #22d3ee;
+  --accent-bg: rgba(34, 211, 238, 0.14);
+  --accent-border: rgba(34, 211, 238, 0.35);
+  --social-bg: rgba(13, 22, 36, 0.7);
+  --shadow:
+    rgba(0, 8, 25, 0.5) 0 14px 35px -12px, rgba(0, 8, 25, 0.4) 0 8px 18px -10px;
+
+  --sans: "Space Grotesk", "Segoe UI", sans-serif;
+  --heading: "Space Grotesk", "Segoe UI", sans-serif;
+  --mono: "JetBrains Mono", Consolas, monospace;
 
   font: 18px/145% var(--sans);
   letter-spacing: 0.18px;
-  color-scheme: light dark;
+  color-scheme: dark;
   color: var(--text);
   background: var(--bg);
   font-synthesis: none;
@@ -32,26 +34,6 @@
 
 @import "tailwindcss";
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --text: #9ca3af;
-    --text-h: #f3f4f6;
-    --bg: #16171d;
-    --border: #2e303a;
-    --code-bg: #1f2028;
-    --accent: #c084fc;
-    --accent-bg: rgba(192, 132, 252, 0.15);
-    --accent-border: rgba(192, 132, 252, 0.5);
-    --social-bg: rgba(47, 48, 58, 0.5);
-    --shadow:
-      rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
-  }
-
-  #social .button-icon {
-    filter: invert(1) brightness(2);
-  }
-}
-
 #root {
    margin: 0;
   min-height: 100%;
@@ -59,6 +41,8 @@
 
 body {
   margin: 0;
+  background: var(--bg);
+  color: var(--text);
 }
 
 @layer base {

--- a/championsclub-frontend/src/pages/AdvisorDashboardPage.tsx
+++ b/championsclub-frontend/src/pages/AdvisorDashboardPage.tsx
@@ -4,8 +4,8 @@ export default function AdvisorDashboardPage() {
   return (
     <AppShell>
       <div className="space-y-4">
-        <h1 className="text-3xl font-bold text-slate-900">Advisor Dashboard</h1>
-        <p className="text-slate-600">
+        <h1 className="text-3xl font-bold text-cyan-100">Advisor Dashboard</h1>
+        <p className="text-slate-400">
           Full advisor dashboard page will be implemented next.
         </p>
       </div>

--- a/championsclub-frontend/src/pages/AdvisorProfilePage.tsx
+++ b/championsclub-frontend/src/pages/AdvisorProfilePage.tsx
@@ -7,8 +7,8 @@ export default function AdvisorProfilePage() {
   return (
     <AppShell>
       <div className="space-y-4">
-        <h1 className="text-3xl font-bold text-slate-900">Advisor Profile</h1>
-        <p className="text-slate-600">Advisor ID: {id}</p>
+        <h1 className="text-3xl font-bold text-cyan-100">Advisor Profile</h1>
+        <p className="text-slate-400">Advisor ID: {id}</p>
       </div>
     </AppShell>
   );

--- a/championsclub-frontend/src/pages/AlertsPage.tsx
+++ b/championsclub-frontend/src/pages/AlertsPage.tsx
@@ -5,14 +5,14 @@ import { alerts } from "../services/mocks/demoData";
 
 const getSeverityClasses = (severity: string) => {
   if (severity === "high") {
-    return "bg-red-100 text-red-700";
+    return "border border-rose-400/30 bg-rose-500/10 text-rose-300";
   }
 
   if (severity === "medium") {
-    return "bg-amber-100 text-amber-700";
+    return "border border-amber-400/30 bg-amber-500/10 text-amber-300";
   }
 
-  return "bg-slate-100 text-slate-700";
+  return "border border-cyan-400/30 bg-cyan-500/10 text-cyan-300";
 };
 
 export default function AlertsPage() {
@@ -22,8 +22,8 @@ export default function AlertsPage() {
     <AppShell>
       <div className="space-y-6">
         <section>
-          <h1 className="text-3xl font-bold text-slate-900">Alerts</h1>
-          <p className="mt-2 text-slate-600">
+          <h1 className="text-3xl font-bold text-cyan-100">Alerts</h1>
+          <p className="mt-2 text-slate-400">
             Review dealership and advisor issues that need manager attention.
           </p>
         </section>
@@ -33,14 +33,14 @@ export default function AlertsPage() {
             {alerts.map((alert) => (
               <div
                 key={alert.id}
-                className="rounded-xl border border-slate-200 p-4"
+                className="rounded-xl border border-[#22354d] bg-[#0c192b] p-4"
               >
                 <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                   <div>
-                    <h2 className="text-lg font-semibold text-slate-900">
+                    <h2 className="text-lg font-semibold text-slate-100">
                       {alert.title}
                     </h2>
-                    <p className="mt-2 text-sm text-slate-600">{alert.summary}</p>
+                    <p className="mt-2 text-sm text-slate-300">{alert.summary}</p>
                   </div>
 
                   <span
@@ -52,20 +52,20 @@ export default function AlertsPage() {
                   </span>
                 </div>
 
-                <div className="mt-4 grid gap-2 text-sm text-slate-500 md:grid-cols-2">
+                <div className="mt-4 grid gap-2 text-sm text-slate-400 md:grid-cols-2">
                   <p>
-                    <span className="font-medium text-slate-700">Advisor:</span>{" "}
+                    <span className="font-medium text-slate-200">Advisor:</span>{" "}
                     {alert.advisorName}
                   </p>
                   <p>
-                    <span className="font-medium text-slate-700">Dealership:</span>{" "}
+                    <span className="font-medium text-slate-200">Dealership:</span>{" "}
                     {alert.dealership}
                   </p>
                 </div>
 
                 <button
                   onClick={() => navigate(`/advisor/${alert.advisorId}`)}
-                  className="mt-4 text-[clamp(0.9rem,0.9vw,1rem)] font-semibold text-slate-900 transition hover:underline"
+                  className="mt-4 text-[clamp(0.9rem,0.9vw,1rem)] font-semibold text-cyan-300 transition hover:text-cyan-200 hover:underline"
                 >
                   View advisor
                 </button>

--- a/championsclub-frontend/src/pages/LeaderboardPage.tsx
+++ b/championsclub-frontend/src/pages/LeaderboardPage.tsx
@@ -4,8 +4,8 @@ export default function LeaderboardPage() {
   return (
     <AppShell>
       <div className="space-y-4">
-        <h1 className="text-3xl font-bold text-slate-900 ">Leaderboard</h1>
-        <p className="text-slate-600">
+        <h1 className="text-3xl font-bold text-cyan-100">Leaderboard</h1>
+        <p className="text-slate-400">
           Full leaderboard page will be implemented next.
         </p>
       </div>

--- a/championsclub-frontend/src/pages/LoginPage.tsx
+++ b/championsclub-frontend/src/pages/LoginPage.tsx
@@ -57,20 +57,29 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-slate-100 px-6">
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#060b13] px-6">
+      <div className="pointer-events-none absolute inset-0 [background-image:radial-gradient(circle_at_15%_15%,rgba(34,211,238,0.16),transparent_28%),radial-gradient(circle_at_85%_10%,rgba(56,189,248,0.14),transparent_30%),linear-gradient(to_bottom,rgba(6,11,19,0.85),rgba(6,11,19,1))]" />
+
+      <div className="pointer-events-none absolute right-[-120px] top-[-80px] h-[340px] w-[340px] rounded-full border border-cyan-400/20 bg-cyan-400/5 blur-2xl" />
+      <div className="pointer-events-none absolute bottom-[-120px] left-[-100px] h-[300px] w-[300px] rounded-full border border-sky-400/20 bg-sky-400/5 blur-2xl" />
+
       <form
         onSubmit={handleLogin}
-        className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-8 shadow-sm"
+        className="relative z-10 w-full max-w-md rounded-2xl border border-[#24405b] bg-[#0b1524]/90 p-8 shadow-[0_20px_50px_rgba(2,8,20,0.55)] backdrop-blur"
       >
-        <h1 className="text-3xl font-bold text-slate-900">ChampionsClub</h1>
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-300/80">
+          Secure Access
+        </p>
 
-        <p className="mt-2 text-slate-600">
+        <h1 className="mt-2 text-3xl font-bold text-cyan-100">ChampionsClub</h1>
+
+        <p className="mt-2 text-slate-300">
           Sign in to access your performance dashboard.
         </p>
 
         <div className="mt-8 space-y-5">
           <div>
-            <label className="mb-2 block text-sm font-medium text-slate-700">
+            <label className="mb-2 block text-sm font-medium text-slate-200">
               Email
             </label>
 
@@ -79,13 +88,13 @@ export default function LoginPage() {
               value={email}
               disabled={isLoading}
               onChange={(event) => setEmail(event.target.value)}
-              className="w-full rounded-xl border border-slate-300 px-4 py-3 text-slate-900 outline-none transition focus:border-slate-900"
+              className="w-full rounded-xl border border-[#2e4663] bg-[#0f1d31] px-4 py-3 text-slate-100 outline-none transition placeholder:text-slate-500 focus:border-cyan-400/70 focus:ring-2 focus:ring-cyan-400/20"
               placeholder="name@example.com"
             />
           </div>
 
           <div>
-            <label className="mb-2 block text-sm font-medium text-slate-700">
+            <label className="mb-2 block text-sm font-medium text-slate-200">
               Password
             </label>
 
@@ -94,13 +103,13 @@ export default function LoginPage() {
               value={password}
               disabled={isLoading}
               onChange={(event) => setPassword(event.target.value)}
-              className="w-full rounded-xl border border-slate-300 px-4 py-3 text-slate-900 outline-none transition focus:border-slate-900"
+              className="w-full rounded-xl border border-[#2e4663] bg-[#0f1d31] px-4 py-3 text-slate-100 outline-none transition placeholder:text-slate-500 focus:border-cyan-400/70 focus:ring-2 focus:ring-cyan-400/20"
               placeholder="Enter your password"
             />
           </div>
 
           {errorMessage && (
-            <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            <div className="rounded-xl border border-rose-400/35 bg-rose-500/10 px-4 py-3 text-sm text-rose-300">
               {errorMessage}
             </div>
           )}
@@ -108,7 +117,7 @@ export default function LoginPage() {
           <button
             type="submit"
             disabled={isLoading}
-            className="w-full rounded-xl bg-slate-900 px-4 py-3 font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
+            className="w-full rounded-xl border border-cyan-400/40 bg-cyan-500/15 px-4 py-3 font-semibold text-cyan-100 transition hover:bg-cyan-500/25 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
           >
             {isLoading ? "Signing in..." : "Login"}
           </button>

--- a/championsclub-frontend/src/pages/ManagerDashboardPage.tsx
+++ b/championsclub-frontend/src/pages/ManagerDashboardPage.tsx
@@ -6,7 +6,7 @@ import LeaderboardPreview from "../features/dashboard/LeaderboardPreview";
 import PriorityAlertsPanel from "../features/dashboard/PriorityAlertsPanel";
 import { useState } from "react";
 import { advisorOptions } from "../services/mocks/demoData";
-import ManagerFilterBar from "../features/dashboard/ManagerFilterBar";
+import ManagerFilterDrawer from "../features/dashboard/ManagerFilterDrawer";
 
 import {
   alerts,
@@ -21,26 +21,28 @@ export default function ManagerDashboardPage() {
   const [selectedUserId, setSelectedUserId] = useState<number | null>(101);
 
   return (
-    <AppShell>
+    <AppShell showTopbar={false}>
       <div className="space-y-6">
-        <section>
-          <h1 className="text-3xl font-bold text-slate-900">
-            Manager Dashboard
-          </h1>
-          <p className="mt-2 text-slate-600">
-            Overview of team performance, alerts, and coaching opportunities.
-          </p>
-        </section>
+        <section className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-cyan-100">
+              Manager Dashboard
+            </h1>
+            <p className="mt-2 text-slate-400">
+              Overview of team performance, alerts, and coaching opportunities.
+            </p>
+          </div>
 
-        <ManagerFilterBar
-         scope={kpiScope}
-        interval={kpiInterval}
-        selectedUserId={selectedUserId}
-        advisors={advisorOptions}
-        onScopeChange={setKpiScope}
-        onIntervalChange={setKpiInterval}
-        onUserChange={setSelectedUserId}
-        />
+          <ManagerFilterDrawer
+            scope={kpiScope}
+            interval={kpiInterval}
+            selectedUserId={selectedUserId}
+            advisors={advisorOptions}
+            onScopeChange={setKpiScope}
+            onIntervalChange={setKpiInterval}
+            onUserChange={setSelectedUserId}
+          />
+        </section>
 
         <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
           {dashboardKpis.map((kpi) => (

--- a/championsclub-frontend/src/pages/ManagerDashboardPage.tsx
+++ b/championsclub-frontend/src/pages/ManagerDashboardPage.tsx
@@ -1,36 +1,162 @@
+import { useEffect, useMemo, useState } from "react";
 import AppShell from "../app/layouts/AppShell";
 import PerformanceTrendChart from "../components/charts/PerformanceTrendChart";
 import AIExecutiveSummary from "../features/dashboard/AIExecutiveSummary";
 import KPIStatCard from "../features/dashboard/KPIStatCard";
 import LeaderboardPreview from "../features/dashboard/LeaderboardPreview";
-import PriorityAlertsPanel from "../features/dashboard/PriorityAlertsPanel";
-import { useState } from "react";
-import { advisorOptions } from "../services/mocks/demoData";
 import ManagerFilterDrawer from "../features/dashboard/ManagerFilterDrawer";
-
+import PriorityAlertsPanel from "../features/dashboard/PriorityAlertsPanel";
+import {
+  mapTeamKpisToCards,
+  mapUserKpisToCards,
+  type DashboardKpiCard,
+} from "../features/dashboard/kpiMapper";
+import {
+  getManagedUsers,
+  getTeamKpis,
+  getUserKpis,
+  type AdvisorOption,
+  type KpiInterval,
+  type KpiScope,
+} from "../services/api/managerStatisticsService";
 import {
   alerts,
-  dashboardKpis,
   leaderboard,
   performanceTrend,
 } from "../services/mocks/demoData";
 
+type StoredUser = {
+  email: string;
+  user_id: number;
+  role: string;
+};
+
+function getCurrentUserFromStorage(): StoredUser | null {
+  const currentUserRaw = localStorage.getItem("currentUser");
+
+  if (!currentUserRaw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(currentUserRaw) as StoredUser;
+  } catch {
+    return null;
+  }
+}
+
 export default function ManagerDashboardPage() {
-   const [kpiScope, setKpiScope] = useState<"team" | "user">("team");
-  const [kpiInterval, setKpiInterval] = useState<"day" | "week" | "month">("week");
-  const [selectedUserId, setSelectedUserId] = useState<number | null>(101);
+  const [kpiScope, setKpiScope] = useState<KpiScope>("team");
+  const [kpiInterval, setKpiInterval] = useState<KpiInterval>("week");
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
+
+  const [advisorOptions, setAdvisorOptions] = useState<AdvisorOption[]>([]);
+  const [isAdvisorsLoading, setIsAdvisorsLoading] = useState(false);
+
+  const [kpiCards, setKpiCards] = useState<DashboardKpiCard[]>([]);
+  const [isKpiLoading, setIsKpiLoading] = useState(false);
+  const [kpiError, setKpiError] = useState("");
+
+  const currentUser = useMemo(() => getCurrentUserFromStorage(), []);
+  const managerId =
+    currentUser?.role?.toLowerCase() === "manager"
+      ? Number(currentUser.user_id)
+      : null;
+
+  useEffect(() => {
+    async function loadManagedUsers() {
+      if (!managerId) {
+        return;
+      }
+
+      try {
+        setIsAdvisorsLoading(true);
+
+        const users = await getManagedUsers(managerId);
+
+        const options = users.map((user) => ({
+          id: user.user_id,
+          name: `${user.first_name} ${user.last_name}`,
+        }));
+
+        setAdvisorOptions(options);
+
+        if (!selectedUserId && options.length > 0) {
+          setSelectedUserId(options[0].id);
+        }
+      } catch (error) {
+        console.error(error);
+        setAdvisorOptions([]);
+      } finally {
+        setIsAdvisorsLoading(false);
+      }
+    }
+
+    loadManagedUsers();
+  }, [managerId]);
+
+  useEffect(() => {
+    async function loadKpis() {
+      if (!managerId) {
+        setKpiError("No manager user found. Please login as manager.");
+        setKpiCards([]);
+        return;
+      }
+
+      setIsKpiLoading(true);
+      setKpiError("");
+
+      try {
+        if (kpiScope === "team") {
+          const response = await getTeamKpis(managerId, kpiInterval);
+          setKpiCards(mapTeamKpisToCards(response.team_kpis));
+          return;
+        }
+
+        if (kpiScope === "user") {
+          if (!selectedUserId) {
+            setKpiCards([]);
+            setKpiError("Please select an advisor.");
+            return;
+          }
+
+          const response = await getUserKpis(
+            managerId,
+            selectedUserId,
+            kpiInterval
+          );
+
+          setKpiCards(mapUserKpisToCards(response));
+        }
+      } catch (error) {
+        console.error(error);
+        setKpiError("Could not load KPI data.");
+        setKpiCards([]);
+      } finally {
+        setIsKpiLoading(false);
+      }
+    }
+
+    loadKpis();
+  }, [managerId, kpiScope, selectedUserId, kpiInterval]);
 
   return (
-    <AppShell showTopbar={false}>
+    <AppShell>
       <div className="space-y-6">
-        <section className="flex flex-wrap items-start justify-between gap-4">
+        <section className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-cyan-100">
+            <h1 className="text-2xl font-bold text-slate-900 md:text-3xl">
               Manager Dashboard
             </h1>
-            <p className="mt-2 text-slate-400">
+            <p className="mt-2 text-sm text-slate-600 md:text-base">
               Overview of team performance, alerts, and coaching opportunities.
             </p>
+
+            {isAdvisorsLoading && (
+              <p className="mt-2 text-sm text-slate-500">
+                Loading managed advisors...
+              </p>
+            )}
           </div>
 
           <ManagerFilterDrawer
@@ -44,27 +170,40 @@ export default function ManagerDashboardPage() {
           />
         </section>
 
-        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {dashboardKpis.map((kpi) => (
-            <KPIStatCard
-              key={kpi.title}
-              title={kpi.title}
-              value={kpi.value}
-              delta={kpi.delta}
-              status={kpi.status as "positive" | "negative" | "neutral"}
-            />
-          ))}
+        <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {isKpiLoading &&
+            [1, 2, 3, 4].map((item) => (
+              <div
+                key={item}
+                className="h-32 animate-pulse rounded-2xl border border-slate-200 bg-white"
+              />
+            ))}
+
+          {kpiError && (
+            <div className="rounded-2xl border border-red-200 bg-red-50 p-5 text-sm text-red-700 sm:col-span-2 xl:col-span-4">
+              {kpiError}
+            </div>
+          )}
+
+          {!isKpiLoading &&
+            !kpiError &&
+            kpiCards.map((kpi) => (
+              <KPIStatCard
+                key={kpi.title}
+                title={kpi.title}
+                value={kpi.value}
+                delta={kpi.delta}
+                status={kpi.status}
+              />
+            ))}
         </section>
 
-        <section className="grid gap-6 xl:grid-cols-[2fr_1fr]">
-          <div className="space-y-6">
-            <PerformanceTrendChart data={performanceTrend} chartIdSuffix="primary" />
-            <PerformanceTrendChart data={performanceTrend} chartIdSuffix="secondary" />
-          </div>
+        <section className="grid grid-cols-1 gap-6">
+          <PerformanceTrendChart data={performanceTrend} />
           <PriorityAlertsPanel alerts={alerts} />
         </section>
 
-        <section className="grid gap-6 xl:grid-cols-2">
+        <section className="grid grid-cols-1 gap-6 xl:grid-cols-2">
           <LeaderboardPreview items={leaderboard} />
           <AIExecutiveSummary />
         </section>

--- a/championsclub-frontend/src/pages/ManagerDashboardPage.tsx
+++ b/championsclub-frontend/src/pages/ManagerDashboardPage.tsx
@@ -4,6 +4,10 @@ import AIExecutiveSummary from "../features/dashboard/AIExecutiveSummary";
 import KPIStatCard from "../features/dashboard/KPIStatCard";
 import LeaderboardPreview from "../features/dashboard/LeaderboardPreview";
 import PriorityAlertsPanel from "../features/dashboard/PriorityAlertsPanel";
+import { useState } from "react";
+import { advisorOptions } from "../services/mocks/demoData";
+import ManagerFilterBar from "../features/dashboard/ManagerFilterBar";
+
 import {
   alerts,
   dashboardKpis,
@@ -12,6 +16,10 @@ import {
 } from "../services/mocks/demoData";
 
 export default function ManagerDashboardPage() {
+   const [kpiScope, setKpiScope] = useState<"team" | "user">("team");
+  const [kpiInterval, setKpiInterval] = useState<"day" | "week" | "month">("week");
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(101);
+
   return (
     <AppShell>
       <div className="space-y-6">
@@ -23,6 +31,16 @@ export default function ManagerDashboardPage() {
             Overview of team performance, alerts, and coaching opportunities.
           </p>
         </section>
+
+        <ManagerFilterBar
+         scope={kpiScope}
+        interval={kpiInterval}
+        selectedUserId={selectedUserId}
+        advisors={advisorOptions}
+        onScopeChange={setKpiScope}
+        onIntervalChange={setKpiInterval}
+        onUserChange={setSelectedUserId}
+        />
 
         <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
           {dashboardKpis.map((kpi) => (

--- a/championsclub-frontend/src/services/api/managerStatisticsService.ts
+++ b/championsclub-frontend/src/services/api/managerStatisticsService.ts
@@ -1,0 +1,116 @@
+//Creating the api service that lets me conect and fetch the data for the manager dashboard, this will be used in the managerDashboardServicece.ts file, and will have functions like getManagerDashboardData, getManagerAlerts, getManagerKpis, etc. For now we will just create the functions and return mock data, but in the future we will connect it to the backend api.
+
+export type KpiInterval = "day" | "week" | "month" | "all";
+export type KpiScope = "team" | "user";
+
+export type TeamKpisData ={
+    total_employees: number;
+    total_points: number;
+    average_points: number;
+    total_credit: number;
+    interval: KpiInterval;
+    total_transactions: number;
+    total_sales_amount: number;
+    total_points_earned: number;
+    total_products_sold: number;
+    last_transaction_date: string | null;
+};
+
+export type TeamKpisResponse = {
+    manager_id: number;
+    team_kpis: TeamKpisData;
+};
+
+export type UserKpiResponse = {
+    user_id: number;
+    first_name: string;
+    last_name: string;
+    email: string;
+    role: string;
+    current_rank: string;
+    total_points: number;
+    credit: number;
+    status: string;
+    interval: KpiInterval;
+    total_transactions: number;
+    total_sales_amount: number;
+    total_points_earned: number;
+    total_products_sold: number;
+    last_transaction_date: string | null;
+};
+
+export type ManagedUserResponse = {
+  user_id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+  role: string;
+  current_rank: string;
+  total_points: number;
+  credit: number;
+  status: string;
+};
+
+export type AdvisorOption ={
+  id: number;
+  name: string;
+}
+
+const API_BASE_URL = "http://localhost:8000";
+
+export async function getManagedUsers(
+  managerId: number
+): Promise<ManagedUserResponse[]> {
+  const response = await fetch(`${API_BASE_URL}/api/manager/dashboard/users`, {
+    headers: {
+      "x-user-id": String(managerId),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch managed users");
+  }
+
+  return response.json();
+}
+
+
+
+export async function getTeamKpis(managerId: number, interval: KpiInterval): Promise<TeamKpisResponse>
+ {
+    const response = await fetch(
+    `${API_BASE_URL}/api/manager/dashboard/team/kpis?interval=${interval}`,
+    {
+      headers: {
+        "x-user-id": String(managerId),
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch team KPIs");
+  }
+
+  return response.json();
+}
+
+export async function getUserKpis(
+  managerId: number,
+  userId: number,
+  interval: KpiInterval
+): Promise<UserKpiResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/manager/dashboard/users/${userId}/kpis?interval=${interval}`,
+    {
+      headers: {
+        "x-user-id": String(managerId),
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch user KPIs");
+  }
+
+  return response.json();
+}

--- a/championsclub-frontend/src/services/mocks/demoData.ts
+++ b/championsclub-frontend/src/services/mocks/demoData.ts
@@ -92,17 +92,4 @@ export const leaderboard = [
   },
 ];
 
-export const advisorOptions = [
-  {
-    id: 101,
-    name: "David Enache",
-  },
-  {
-    id: 102,
-    name: "Ioana Matei",
-  },
-  {
-    id: 103,
-    name: "Radu Pavel",
-  },
-];
+export const advisorOptions: Array<{ id: number; name: string }> = [];

--- a/championsclub-frontend/src/services/mocks/demoData.ts
+++ b/championsclub-frontend/src/services/mocks/demoData.ts
@@ -91,3 +91,18 @@ export const leaderboard = [
     tier: "Silver",
   },
 ];
+
+export const advisorOptions = [
+  {
+    id: 101,
+    name: "David Enache",
+  },
+  {
+    id: 102,
+    name: "Ioana Matei",
+  },
+  {
+    id: 103,
+    name: "Radu Pavel",
+  },
+];


### PR DESCRIPTION
This PR introduces full integration between the frontend Manager Dashboard and backend KPI endpoints, replacing mock data with real data and enabling dynamic filtering.

What was implemented

Authentication Integration
-Uses stored currentUser from login (localStorage)
-Extracts user_id to identify the logged-in manager
-Sends x-user-id header with all KPI requests


 KPI Backend Integration

Connected frontend to:
-GET /api/manager/dashboard/team/kpis
-GET /api/manager/dashboard/users/{user_id}/kpis
-Replaced mock KPI data with real backend responses
-Implemented mapping layer (kpiMappers.ts) to transform backend response into UI card format


 Filter Drawer (Manager Control Panel):

-Implemented filter drawer component (ManagerFilterDrawer)
-Allows manager to:
-Switch between Team and Advisor KPIs
-Select specific advisor (when scope = user)
-Select KPI interval:
Day,Week,Month,All


 Dynamic Advisor Loading:
-Integrated new backend endpoint:
-GET /api/manager/dashboard/users
-Fetches advisors under the logged-in manager
-Populates advisor filter dynamically (no more mock data)


 Dynamic KPI Updates
-KPI cards update automatically based on:
-selected scope (team/user)
-selected advisor
-selected time interval
-Uses useEffect to trigger data fetching on filter changes

State Management:

Added state for:

-kpiScope
-kpiInterval
-selectedUserId
-advisorOptions
-loading and error handling


 Error & Loading Handling:

-Loading skeletons for KPI cards
-Graceful error messages when API fails
-Validation for missing advisor selection