### PR TITLE
implemented AdvisorProfileDetails for ManagerDashboard

### DIFF
--- a/championsclub-frontend/src/app/router/index.tsx
+++ b/championsclub-frontend/src/app/router/index.tsx
@@ -1,4 +1,4 @@
-//Definim rutele principale pentru aplicatie, folosind react-router-dom cum ar fi /login, /dashboard, /alerts, /advisor/:id, /leaderboard
+//Definim rutele principale pentru aplicatie, folosind react-router-dom cum ar fi /login, /dashboard, /alerts, /manager/advisor/:id, /leaderboard
 import { Routes, Route, Navigate } from "react-router-dom";
 import LoginPage from "../../pages/LoginPage";
 import ManagerDashboardPage from "../../pages/ManagerDashboardPage";
@@ -13,6 +13,7 @@ export default function AppRouter() {
             <Route path="/login" element={<LoginPage />} />
             <Route path="/dashboard" element={<ManagerDashboardPage />} />
             <Route path="/alerts" element={<AlertsPage />} />
+            <Route path="/manager/advisor/:id" element={<AdvisorProfilePage />} />
             <Route path="/advisor/:id" element={<AdvisorProfilePage />} />
             <Route path="/advisor-dashboard" element={<AdvisorDashboardPage />} />
             <Route path="/leaderboard" element={<LeaderboardPage />} /> 

--- a/championsclub-frontend/src/features/dashboard/PriorityAlertsPanel.tsx
+++ b/championsclub-frontend/src/features/dashboard/PriorityAlertsPanel.tsx
@@ -129,7 +129,7 @@ export default function PriorityAlertsPanel({
                 </span>
 
                 <button
-                  onClick={() => navigate(`/advisor/${alert.advisorId}`)}
+                  onClick={() => navigate(`/manager/advisor/${alert.advisorId}`)}
                   className={`rounded-lg px-4 py-2 text-sm font-semibold transition ${getSeverityButtonClasses(
                     alert.severity
                   )}`}

--- a/championsclub-frontend/src/pages/AdvisorDashboardPage.tsx
+++ b/championsclub-frontend/src/pages/AdvisorDashboardPage.tsx
@@ -1,13 +1,213 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { LayoutDashboard, Mail, ShieldCheck, Trophy, UserRound } from "lucide-react";
 import AppShell from "../app/layouts/AppShell";
+import Card from "../components/ui/Card";
+
+type StoredUser = {
+  email: string;
+  user_id: number;
+  role: string;
+};
+
+function getCurrentUserFromStorage(): StoredUser | null {
+  const currentUserRaw = localStorage.getItem("currentUser");
+
+  if (!currentUserRaw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(currentUserRaw) as StoredUser;
+  } catch {
+    return null;
+  }
+}
+
+function toTitleCase(value: string) {
+  return value
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(" ");
+}
 
 export default function AdvisorDashboardPage() {
+  const currentUser = useMemo(() => getCurrentUserFromStorage(), []);
+  const isAdvisor = currentUser?.role?.toLowerCase() === "sales_advisor";
+
   return (
     <AppShell>
-      <div className="space-y-4">
-        <h1 className="text-3xl font-bold text-cyan-100">Advisor Dashboard</h1>
-        <p className="text-slate-400">
-          Full advisor dashboard page will be implemented next.
-        </p>
+      <div className="space-y-6">
+        <section className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-cyan-100">Advisor Dashboard</h1>
+            <p className="mt-2 text-slate-400">
+              Personal workspace for account details and self-service progress overview.
+            </p>
+          </div>
+
+          <Card className="w-full max-w-md border-[#28415f] bg-[#0d1a2b]">
+            <p className="text-sm font-semibold text-cyan-100">Session Status</p>
+            <p className="mt-2 text-sm text-slate-300">
+              {isAdvisor
+                ? "You are signed in as sales advisor."
+                : "Current session is not a sales advisor account."}
+            </p>
+          </Card>
+        </section>
+
+        {!currentUser && (
+          <Card className="border border-rose-500/40 bg-rose-500/10">
+            <h2 className="text-lg font-semibold text-rose-200">Session not found</h2>
+            <p className="mt-2 text-sm text-rose-100/90">
+              The advisor dashboard requires an authenticated advisor session.
+            </p>
+          </Card>
+        )}
+
+        {currentUser && (
+          <>
+            <section className="grid grid-cols-1 gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+              <Card className="border border-[#28415f] bg-[#0d1a2b]">
+                <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+                  <div>
+                    <div className="inline-flex h-14 w-14 items-center justify-center rounded-2xl border border-cyan-500/30 bg-cyan-500/10 text-cyan-200">
+                      <UserRound className="h-7 w-7" />
+                    </div>
+                    <h2 className="mt-4 text-2xl font-bold text-slate-100">
+                      Advisor Account
+                    </h2>
+                    <p className="mt-2 flex items-center gap-2 text-sm text-slate-300">
+                      <Mail className="h-4 w-4 text-cyan-300" />
+                      {currentUser.email}
+                    </p>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-2 lg:max-w-sm lg:flex-1">
+                    <div className="rounded-xl border border-[#29405b] bg-[#081322] p-4">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        Role
+                      </p>
+                      <p className="mt-2 flex items-center gap-2 text-sm font-medium text-slate-100">
+                        <ShieldCheck className="h-4 w-4 text-cyan-300" />
+                        {toTitleCase(currentUser.role)}
+                      </p>
+                    </div>
+
+                    <div className="rounded-xl border border-[#29405b] bg-[#081322] p-4">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        User ID
+                      </p>
+                      <p className="mt-2 text-sm font-medium text-slate-100">
+                        {currentUser.user_id}
+                      </p>
+                    </div>
+
+                    <div className="rounded-xl border border-[#29405b] bg-[#081322] p-4 sm:col-span-2">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        Dashboard Mode
+                      </p>
+                      <p className="mt-2 flex items-center gap-2 text-sm font-medium text-slate-100">
+                        <LayoutDashboard className="h-4 w-4 text-cyan-300" />
+                        Self-service advisor view
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </Card>
+
+              <Card className="border border-[#28415f] bg-[#0d1a2b]">
+                <h2 className="text-lg font-semibold text-cyan-100">
+                  Profile Snapshot
+                </h2>
+                <div className="mt-4 space-y-4">
+                  <div className="rounded-xl border border-[#29405b] bg-[#081322] p-4">
+                    <p className="text-sm text-slate-400">Access Type</p>
+                    <p className="mt-2 text-lg font-semibold text-slate-100">
+                      Personal login session
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl border border-[#29405b] bg-[#081322] p-4">
+                    <p className="text-sm text-slate-400">Email</p>
+                    <p className="mt-2 text-lg font-semibold text-slate-100 break-all">
+                      {currentUser.email}
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl border border-[#29405b] bg-[#081322] p-4">
+                    <p className="text-sm text-slate-400">Navigation</p>
+                    <p className="mt-2 text-lg font-semibold text-cyan-100">
+                      Advisor-only route
+                    </p>
+                  </div>
+                </div>
+              </Card>
+            </section>
+
+            <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              <Card className="border border-[#28415f] bg-[#0d1a2b]">
+                <p className="text-sm text-slate-400">Account Role</p>
+                <p className="mt-2 text-2xl font-bold text-slate-100">
+                  {toTitleCase(currentUser.role)}
+                </p>
+              </Card>
+              <Card className="border border-[#28415f] bg-[#0d1a2b]">
+                <p className="text-sm text-slate-400">Session User ID</p>
+                <p className="mt-2 text-2xl font-bold text-slate-100">
+                  {currentUser.user_id}
+                </p>
+              </Card>
+              <Card className="border border-[#28415f] bg-[#0d1a2b]">
+                <p className="text-sm text-slate-400">Account Email</p>
+                <p className="mt-2 text-lg font-bold text-slate-100 break-all">
+                  {currentUser.email}
+                </p>
+              </Card>
+              <Card className="border border-[#28415f] bg-[#0d1a2b]">
+                <p className="text-sm text-slate-400">Current Rank</p>
+                <p className="mt-2 flex items-center gap-2 text-2xl font-bold text-slate-100">
+                  <Trophy className="h-5 w-5 text-amber-300" />
+                  Pending API
+                </p>
+              </Card>
+            </section>
+
+            <section className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+              <Card className="border border-[#28415f] bg-[#0d1a2b]">
+                <h2 className="text-lg font-semibold text-cyan-100">
+                  Advisor Summary
+                </h2>
+                <div className="mt-4 space-y-4">
+                  <div className="rounded-xl border border-cyan-500/30 bg-cyan-500/10 p-4">
+                    <p className="text-sm font-semibold text-cyan-100">
+                      Chat Generated Message
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-slate-200">
+                      You are signed in as {toTitleCase(currentUser.role)} with account ID {currentUser.user_id}. This page is now isolated from the manager advisor-detail flow, so manager drill-downs and advisor self-view no longer share the same route. KPI details for self-view still need a dedicated advisor endpoint before this page can show live rank, points, transactions, and sales values.
+                    </p>
+                  </div>
+                </div>
+              </Card>
+
+              <Card className="border border-[#28415f] bg-[#0d1a2b]">
+                <h2 className="text-lg font-semibold text-cyan-100">
+                  Next Available Navigation
+                </h2>
+                <div className="mt-4 space-y-4">
+                  <Link
+                    to="/leaderboard"
+                    className="flex items-center justify-between rounded-xl border border-[#29405b] bg-[#081322] px-4 py-3 text-sm font-medium text-slate-100 transition hover:bg-[#112238]"
+                  >
+                    <span>Open leaderboard</span>
+                    <span className="text-cyan-300">Go</span>
+                  </Link>
+                </div>
+              </Card>
+            </section>
+          </>
+        )}
       </div>
     </AppShell>
   );

--- a/championsclub-frontend/src/pages/AdvisorProfilePage.tsx
+++ b/championsclub-frontend/src/pages/AdvisorProfilePage.tsx
@@ -1,14 +1,345 @@
-import { useParams } from "react-router-dom";
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowLeft, Mail, ShieldCheck, Trophy, UserRound } from "lucide-react";
+import { Link, useParams } from "react-router-dom";
 import AppShell from "../app/layouts/AppShell";
+import Card from "../components/ui/Card";
+import KPIStatCard from "../features/dashboard/KPIStatCard";
+import {
+  getAdvisorProfileKpis,
+  type KpiInterval,
+  type UserKpiResponse,
+} from "../services/api/managerStatisticsService";
+
+type StoredUser = {
+  email: string;
+  user_id: number;
+  role: string;
+};
+
+const intervalOptions: KpiInterval[] = ["all", "day", "week", "month"];
+
+function getCurrentUserFromStorage(): StoredUser | null {
+  const currentUserRaw = localStorage.getItem("currentUser");
+
+  if (!currentUserRaw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(currentUserRaw) as StoredUser;
+  } catch {
+    return null;
+  }
+}
+
+function formatCurrency(value: number) {
+  return `€${Number(value).toLocaleString()}`;
+}
+
+function formatDate(value: string | null) {
+  if (!value) {
+    return "No transactions yet";
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  }).format(date);
+}
+
+function toTitleCase(value: string) {
+  return value
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function buildChatGeneratedMessage(advisor: UserKpiResponse, interval: KpiInterval) {
+  const intervalLabel = interval === "all" ? "all tracked periods" : `the selected ${interval} interval`;
+  const lastTransaction = advisor.last_transaction_date
+    ? `The most recent transaction was recorded on ${formatDate(advisor.last_transaction_date)}.`
+    : "There is no recorded transaction yet for this advisor.";
+
+  return `${advisor.first_name} ${advisor.last_name} is currently ranked ${advisor.current_rank} with ${Number(
+    advisor.total_points
+  ).toLocaleString()} total points and ${Number(advisor.credit).toLocaleString()} credit. Across ${intervalLabel}, the advisor closed ${advisor.total_transactions} transactions, generated ${formatCurrency(
+    advisor.total_sales_amount
+  )} in sales, and sold ${advisor.total_products_sold} products for ${Number(
+    advisor.total_points_earned
+  ).toLocaleString()} earned points. ${lastTransaction}`;
+}
 
 export default function AdvisorProfilePage() {
   const { id } = useParams();
+  const [interval, setInterval] = useState<KpiInterval>("all");
+
+  const currentUser = useMemo(() => getCurrentUserFromStorage(), []);
+  const managerId =
+    currentUser?.role?.toLowerCase() === "manager"
+      ? Number(currentUser.user_id)
+      : null;
+  const advisorId = Number(id);
+  const hasValidAdvisorId = Number.isInteger(advisorId) && advisorId > 0;
+
+  const {
+    data: advisor,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ["advisor-profile-kpis", managerId, advisorId, interval],
+    queryFn: () => getAdvisorProfileKpis(managerId as number, advisorId, interval),
+    enabled: Boolean(managerId) && hasValidAdvisorId,
+    retry: false,
+  });
+
+  const stats = advisor
+    ? [
+        {
+          title: "Total Points",
+          value: Number(advisor.total_points).toLocaleString(),
+          delta: advisor.current_rank,
+          status: "positive" as const,
+        },
+        {
+          title: "Credit",
+          value: Number(advisor.credit).toLocaleString(),
+          delta: "Redeemable balance",
+          status: "neutral" as const,
+        },
+        {
+          title: "Total Transactions",
+          value: String(advisor.total_transactions),
+          delta: `${toTitleCase(interval)} interval`,
+          status: "neutral" as const,
+        },
+        {
+          title: "Sales Amount",
+          value: formatCurrency(advisor.total_sales_amount),
+          delta: `${advisor.total_products_sold} products sold`,
+          status: "positive" as const,
+        },
+      ]
+    : [];
+
+  const showAccessError = !hasValidAdvisorId || !managerId || isError;
+  const chatGeneratedMessage = advisor
+    ? buildChatGeneratedMessage(advisor, interval)
+    : "";
 
   return (
     <AppShell>
-      <div className="space-y-4">
-        <h1 className="text-3xl font-bold text-cyan-100">Advisor Profile</h1>
-        <p className="text-slate-400">Advisor ID: {id}</p>
+      <div className="space-y-6">
+        <section className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <Link
+              to="/dashboard"
+              className="inline-flex items-center gap-2 text-sm font-medium text-cyan-300 transition hover:text-cyan-100"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back to dashboard
+            </Link>
+
+            <h1 className="mt-3 text-2xl font-bold text-cyan-100 md:text-3xl">
+              Advisor Profile
+            </h1>
+            <p className="mt-2 text-sm text-slate-400 md:text-base">
+              Review advisor performance, current standing, and recent activity.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+            {intervalOptions.map((option) => (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={interval === option}
+                onClick={() => setInterval(option)}
+                className={`min-w-[58px] rounded-full border px-4 py-2 text-sm font-semibold capitalize leading-none transition ${
+                  interval === option
+                    ? "border-cyan-500/60 bg-cyan-500/18 text-cyan-100 shadow-[0_0_18px_rgba(6,182,212,0.18)]"
+                    : "border-[#29405b] bg-[#081322] text-slate-300 hover:border-cyan-500/30 hover:bg-[#112238] hover:text-cyan-100"
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {isLoading && (
+          <>
+            <div className="grid grid-cols-1 gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+              <div className="h-56 animate-pulse rounded-2xl border border-[#29405b] bg-[#0d1a2b]" />
+              <div className="h-56 animate-pulse rounded-2xl border border-[#29405b] bg-[#0d1a2b]" />
+            </div>
+            <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              {[1, 2, 3, 4].map((item) => (
+                <div
+                  key={item}
+                  className="h-32 animate-pulse rounded-2xl border border-[#29405b] bg-[#0d1a2b]"
+                />
+              ))}
+            </section>
+          </>
+        )}
+
+        {showAccessError && !isLoading && (
+          <Card className="border border-rose-500/40 bg-rose-500/10">
+            <h2 className="text-lg font-semibold text-rose-200">
+              Advisor could not be loaded
+            </h2>
+            <p className="mt-2 text-sm text-rose-100/90">
+              The advisor does not exist, is not assigned to the current manager, or the current manager session is missing.
+            </p>
+          </Card>
+        )}
+
+        {advisor && !isLoading && !showAccessError && (
+          <>
+            <section className="grid grid-cols-1 gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+              <Card className="border border-[#28415f] bg-[#0d1a2b]">
+                <div className="flex flex-col items-center gap-6 text-center">
+                  <div className="flex flex-col items-center">
+                    <div className="inline-flex h-14 w-14 items-center justify-center rounded-2xl border border-cyan-500/30 bg-cyan-500/10 text-cyan-200">
+                      <UserRound className="h-7 w-7" />
+                    </div>
+                    <h2 className="mt-4 text-2xl font-bold text-slate-100">
+                      {advisor.first_name} {advisor.last_name}
+                    </h2>
+                    <p className="mt-2 flex items-center gap-2 text-sm text-slate-300">
+                      <Mail className="h-4 w-4 text-cyan-300" />
+                      {advisor.email}
+                    </p>
+                  </div>
+
+                  <div className="grid w-full max-w-2xl gap-3 sm:grid-cols-2">
+                    <div className="rounded-xl border border-[#29405b] bg-[#081322] p-4">
+                      <p className="text-center text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        Role
+                      </p>
+                      <p className="mt-2 flex items-center justify-center gap-2 text-sm font-medium text-slate-100">
+                        <ShieldCheck className="h-4 w-4 text-cyan-300" />
+                        {toTitleCase(advisor.role)}
+                      </p>
+                    </div>
+
+                    <div className="rounded-xl border border-[#29405b] bg-[#081322] p-4">
+                      <p className="text-center text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        Status
+                      </p>
+                      <p className="mt-2 text-center text-sm font-medium text-slate-100">
+                        {toTitleCase(advisor.status)}
+                      </p>
+                    </div>
+
+                    <div className="rounded-xl border border-[#29405b] bg-[#081322] p-4 sm:col-span-2">
+                      <p className="text-center text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        Current Rank
+                      </p>
+                      <p className="mt-2 flex items-center justify-center gap-2 text-sm font-medium text-slate-100">
+                        <Trophy className="h-4 w-4 text-amber-300" />
+                        {advisor.current_rank}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </Card>
+
+              <Card className="border border-[#28415f] bg-[#0d1a2b]">
+                <h2 className="text-lg font-semibold text-cyan-100">
+                  Profile Snapshot
+                </h2>
+                <div className="mt-4 space-y-4">
+                  <div className="rounded-xl border border-[#29405b] bg-[#081322] p-4">
+                    <p className="text-sm text-slate-400">Advisor ID</p>
+                    <p className="mt-2 text-2xl font-bold text-slate-100">
+                      {advisor.user_id}
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl border border-[#29405b] bg-[#081322] p-4">
+                    <p className="text-sm text-slate-400">Last Transaction Date</p>
+                    <p className="mt-2 text-lg font-semibold text-slate-100">
+                      {formatDate(advisor.last_transaction_date)}
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl border border-[#29405b] bg-[#081322] p-4">
+                    <p className="text-sm text-slate-400">Selected Interval</p>
+                    <p className="mt-2 text-lg font-semibold capitalize text-cyan-100">
+                      {interval}
+                    </p>
+                  </div>
+                </div>
+              </Card>
+            </section>
+
+            <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              {stats.map((stat) => (
+                <KPIStatCard
+                  key={stat.title}
+                  title={stat.title}
+                  value={stat.value}
+                  delta={stat.delta}
+                  status={stat.status}
+                />
+              ))}
+            </section>
+
+            <section>
+              <div className="flex flex-col gap-3 rounded-2xl border border-dashed border-cyan-500/30 bg-cyan-500/5 px-5 py-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-cyan-100">
+                    Performance Popup Slot
+                  </p>
+                  <p className="mt-1 text-sm text-slate-400">
+                    Reserved trigger area for the upcoming advisor performance popup.
+                  </p>
+                </div>
+
+                <button
+                  type="button"
+                  disabled
+                  aria-disabled="true"
+                  aria-haspopup="dialog"
+                  data-popup-slot="advisor-performance"
+                  className="rounded-xl border border-cyan-500/40 bg-cyan-500/10 px-4 py-2 text-sm font-semibold text-cyan-100 opacity-70"
+                >
+                  Open performance details
+                </button>
+              </div>
+            </section>
+
+            <section>
+              <Card className="border border-[#28415f] bg-[#0d1a2b]">
+                <h2 className="text-lg font-semibold text-cyan-100">
+                  Activity Summary
+                </h2>
+                <div className="mt-4">
+                  <div className="rounded-xl border border-cyan-500/30 bg-cyan-500/10 p-4">
+                    <p className="text-sm font-semibold text-cyan-100">
+                      Chat Generated Message
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-slate-200">
+                      {chatGeneratedMessage}
+                    </p>
+                  </div>
+                </div>
+              </Card>
+            </section>
+          </>
+        )}
       </div>
     </AppShell>
   );

--- a/championsclub-frontend/src/pages/AlertsPage.tsx
+++ b/championsclub-frontend/src/pages/AlertsPage.tsx
@@ -264,7 +264,7 @@ const unreadAlertsCount = notificationsData?.unread_alerts ?? 0;
                     </span>
 
                     <button
-                      onClick={() => navigate(`/advisor/${alert.user_id}`)}
+                      onClick={() => navigate(`/manager/advisor/${alert.user_id}`)}
                       className={`rounded-lg px-4 py-2 text-sm font-semibold transition ${getSeverityButtonClasses(
                         alert.priority
                       )}`}

--- a/championsclub-frontend/src/pages/LoginPage.tsx
+++ b/championsclub-frontend/src/pages/LoginPage.tsx
@@ -40,7 +40,7 @@ export default function LoginPage() {
       }
 
       if (role === "sales_advisor") {
-        navigate(`/advisor/${user.user_id}`);
+        navigate("/advisor-dashboard");
         return;
       }
 

--- a/championsclub-frontend/src/services/api/managerStatisticsService.ts
+++ b/championsclub-frontend/src/services/api/managerStatisticsService.ts
@@ -114,3 +114,24 @@ export async function getUserKpis(
 
   return response.json();
 }
+
+export async function getAdvisorProfileKpis(
+  managerId: number,
+  userId: number,
+  interval: KpiInterval
+): Promise<UserKpiResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/manager/profile/users/${userId}/kpis?interval=${interval}`,
+    {
+      headers: {
+        "x-user-id": String(managerId),
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch advisor profile KPIs");
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
Am implementat pagina manager-facing pentru advisor details, accesibilă din alerts/dashboard, cu fetch pe baza [advisor id] din rută și [manager id] din [localStorage], folosind endpointul existent de profile KPI. Am păstrat stilul vizual din manager dashboard, am adăugat filtrare pe interval (all, day, week, month), loading/error states și un Activity Summary narativ.

Pe lângă asta, am separat fluxul managerului de cel pentru [sales_advisor]: managerul folosește ruta explicită de advisor details, iar advisorul are propria pagină de self-view. Am simplificat pagina de advisor details ca să nu repete KPI-urile, am centrat mai bine informațiile de profil și am pregătit un slot clar pentru viitorul popup de performance.