### PR TITLE
[Backend] Sales Advisor Dashboard Overview

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from app.manager_alerts.manager_notifications_router import router as manager_no
 from app.leaderboard.router import router as leaderboard_router
 from app.AI.summary.manager_router import router as ai_summary_router
 from app.AI.activity_summary.activity_summary_router import router as ai_activity_summary_router
+from app.sales_advisor_dashboard.overview_router import router as sales_advisor_dashboard_router
 
 
 from fastapi.middleware.cors import CORSMiddleware
@@ -37,6 +38,7 @@ app.include_router(leaderboard_router)
 app.include_router(account_router)
 app.include_router(ai_summary_router)
 app.include_router(ai_activity_summary_router)
+app.include_router(sales_advisor_dashboard_router)
 
 app.include_router(manager_notifications_router)
 

--- a/backend/app/sales_advisor_dashboard/overview_repository.py
+++ b/backend/app/sales_advisor_dashboard/overview_repository.py
@@ -1,0 +1,16 @@
+from sqlmodel import Session, select
+
+from app.models.app_user import AppUser
+
+
+def get_sales_advisor_team_members(
+    session: Session,
+    manager_user_id: int,
+) -> list[AppUser]:
+    statement = (
+        select(AppUser)
+        .where(AppUser.manager_user_id == manager_user_id)
+        .where(AppUser.role.ilike("sales_advisor"))
+    )
+
+    return list(session.exec(statement).all())

--- a/backend/app/sales_advisor_dashboard/overview_router.py
+++ b/backend/app/sales_advisor_dashboard/overview_router.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends
+from sqlmodel import Session
+
+from app.database import get_session
+from app.manager_statistics.router import get_current_user
+from app.models.app_user import AppUser
+from app.sales_advisor_dashboard.overview_schemas import (
+    SalesAdvisorDashboardOverviewResponse,
+)
+from app.sales_advisor_dashboard.overview_service import (
+    get_sales_advisor_dashboard_overview,
+)
+
+
+router = APIRouter(
+    prefix="/api/sales-advisor/dashboard",
+    tags=["sales-advisor-dashboard"],
+)
+
+
+@router.get(
+    "/overview",
+    response_model=SalesAdvisorDashboardOverviewResponse,
+    status_code=200,
+)
+def read_sales_advisor_dashboard_overview(
+    session: Session = Depends(get_session),
+    current_user: AppUser = Depends(get_current_user),
+):
+    return get_sales_advisor_dashboard_overview(
+        session=session,
+        current_user=current_user,
+    )

--- a/backend/app/sales_advisor_dashboard/overview_schemas.py
+++ b/backend/app/sales_advisor_dashboard/overview_schemas.py
@@ -1,0 +1,68 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+TeamAverageComparison = Literal["above", "below", "equal"]
+
+
+class DashboardSummaryResponse(BaseModel):
+    user_id: int
+    current_points: int
+    current_rank: str
+    next_rank: str | None
+    points_to_next_rank: int | None
+    is_highest_rank: bool
+
+
+class RankProgressResponse(BaseModel):
+    current_rank: str
+    current_rank_min_points: int
+    next_rank: str | None
+    next_rank_min_points: int | None
+    current_points: int
+    points_to_next_rank: int | None
+    progress_percentage: float
+    is_highest_rank: bool
+
+
+class TeamComparisonResponse(BaseModel):
+    team_average_points: float
+    comparison_to_team_average: TeamAverageComparison
+    points_difference_from_average: float
+    team_position: int
+    total_sales_advisors: int
+
+
+class PointsComparisonChartPoint(BaseModel):
+    label: str
+    points: float
+
+
+class RankProgressChartData(BaseModel):
+    label: str
+    current_points: int
+    start_points: int
+    target_points: int | None
+    progress_percentage: float
+    remaining_points: int | None
+
+
+class TeamPositionChartData(BaseModel):
+    team_position: int
+    total_sales_advisors: int
+    advisors_ahead: int
+    advisors_behind: int
+
+
+class SalesAdvisorOverviewChartData(BaseModel):
+    personal_points_vs_team_average: list[PointsComparisonChartPoint] | None
+    rank_progress_toward_next_rank: RankProgressChartData
+    team_position_summary: TeamPositionChartData | None
+
+
+class SalesAdvisorDashboardOverviewResponse(BaseModel):
+    dashboard_summary: DashboardSummaryResponse
+    rank_progress: RankProgressResponse
+    team_comparison: TeamComparisonResponse | None
+    chart_data: SalesAdvisorOverviewChartData

--- a/backend/app/sales_advisor_dashboard/overview_service.py
+++ b/backend/app/sales_advisor_dashboard/overview_service.py
@@ -1,0 +1,230 @@
+from fastapi import HTTPException
+from sqlmodel import Session
+
+from app.models.app_user import AppUser
+from app.sales_advisor_dashboard.overview_repository import (
+    get_sales_advisor_team_members,
+)
+from app.sales_advisor_dashboard.overview_schemas import (
+    DashboardSummaryResponse,
+    PointsComparisonChartPoint,
+    RankProgressChartData,
+    RankProgressResponse,
+    SalesAdvisorDashboardOverviewResponse,
+    SalesAdvisorOverviewChartData,
+    TeamAverageComparison,
+    TeamComparisonResponse,
+    TeamPositionChartData,
+)
+
+
+RANK_THRESHOLDS: tuple[tuple[str, int], ...] = (
+    ("Default", 0),
+    ("Bronze", 500),
+    ("Silver", 1000),
+    ("Gold", 2000),
+)
+
+
+def validate_sales_advisor(current_user: AppUser) -> None:
+    if current_user.role.lower() != "sales_advisor":
+        raise HTTPException(
+            status_code=403,
+            detail="Access denied: Sales advisor role required",
+        )
+
+
+def get_current_rank_for_points(points: int) -> tuple[str, int]:
+    current_rank = RANK_THRESHOLDS[0]
+
+    for rank in RANK_THRESHOLDS:
+        if points >= rank[1]:
+            current_rank = rank
+        else:
+            break
+
+    return current_rank
+
+
+def get_next_rank_for_points(points: int) -> tuple[str, int] | None:
+    for rank in RANK_THRESHOLDS:
+        if points < rank[1]:
+            return rank
+
+    return None
+
+
+def build_rank_progress(points: int) -> RankProgressResponse:
+    current_rank, current_rank_min_points = get_current_rank_for_points(points)
+    next_rank = get_next_rank_for_points(points)
+
+    if next_rank is None:
+        return RankProgressResponse(
+            current_rank=current_rank,
+            current_rank_min_points=current_rank_min_points,
+            next_rank=None,
+            next_rank_min_points=None,
+            current_points=points,
+            points_to_next_rank=None,
+            progress_percentage=100.0,
+            is_highest_rank=True,
+        )
+
+    next_rank_name, next_rank_min_points = next_rank
+    rank_span = next_rank_min_points - current_rank_min_points
+    points_in_rank = max(points - current_rank_min_points, 0)
+    progress_percentage = round((points_in_rank / rank_span) * 100, 2)
+
+    return RankProgressResponse(
+        current_rank=current_rank,
+        current_rank_min_points=current_rank_min_points,
+        next_rank=next_rank_name,
+        next_rank_min_points=next_rank_min_points,
+        current_points=points,
+        points_to_next_rank=max(next_rank_min_points - points, 0),
+        progress_percentage=min(progress_percentage, 100.0),
+        is_highest_rank=False,
+    )
+
+
+def compare_to_team_average(points: int, team_average: float) -> TeamAverageComparison:
+    if points > team_average:
+        return "above"
+    if points < team_average:
+        return "below"
+    return "equal"
+
+
+def ensure_current_user_in_team(
+    current_user: AppUser,
+    team_members: list[AppUser],
+) -> list[AppUser]:
+    if any(member.user_id == current_user.user_id for member in team_members):
+        return team_members
+
+    return [*team_members, current_user]
+
+
+def get_team_position(current_user: AppUser, team_members: list[AppUser]) -> int:
+    sorted_members = sorted(
+        team_members,
+        key=lambda member: (
+            -(member.points or 0),
+            (member.last_name or "").lower(),
+            (member.first_name or "").lower(),
+            member.user_id or 0,
+        ),
+    )
+
+    for index, member in enumerate(sorted_members, start=1):
+        if member.user_id == current_user.user_id:
+            return index
+
+    return len(sorted_members)
+
+
+def build_team_comparison(
+    current_user: AppUser,
+    team_members: list[AppUser],
+) -> TeamComparisonResponse:
+    current_points = current_user.points or 0
+    total_sales_advisors = len(team_members)
+    total_points = sum(member.points or 0 for member in team_members)
+    team_average = total_points / total_sales_advisors if total_sales_advisors else 0
+    team_position = get_team_position(current_user, team_members)
+
+    return TeamComparisonResponse(
+        team_average_points=round(team_average, 2),
+        comparison_to_team_average=compare_to_team_average(current_points, team_average),
+        points_difference_from_average=round(current_points - team_average, 2),
+        team_position=team_position,
+        total_sales_advisors=total_sales_advisors,
+    )
+
+
+def build_rank_progress_chart(
+    rank_progress: RankProgressResponse,
+) -> RankProgressChartData:
+    label = (
+        f"{rank_progress.current_rank} to {rank_progress.next_rank}"
+        if rank_progress.next_rank is not None
+        else "Highest rank"
+    )
+
+    return RankProgressChartData(
+        label=label,
+        current_points=rank_progress.current_points,
+        start_points=rank_progress.current_rank_min_points,
+        target_points=rank_progress.next_rank_min_points,
+        progress_percentage=rank_progress.progress_percentage,
+        remaining_points=rank_progress.points_to_next_rank,
+    )
+
+
+def build_chart_data(
+    current_points: int,
+    rank_progress: RankProgressResponse,
+    team_comparison: TeamComparisonResponse | None,
+) -> SalesAdvisorOverviewChartData:
+    personal_points_vs_team_average = None
+    team_position_summary = None
+
+    if team_comparison is not None:
+        personal_points_vs_team_average = [
+            PointsComparisonChartPoint(label="Personal", points=float(current_points)),
+            PointsComparisonChartPoint(
+                label="Team average",
+                points=team_comparison.team_average_points,
+            ),
+        ]
+        team_position_summary = TeamPositionChartData(
+            team_position=team_comparison.team_position,
+            total_sales_advisors=team_comparison.total_sales_advisors,
+            advisors_ahead=team_comparison.team_position - 1,
+            advisors_behind=(
+                team_comparison.total_sales_advisors - team_comparison.team_position
+            ),
+        )
+
+    return SalesAdvisorOverviewChartData(
+        personal_points_vs_team_average=personal_points_vs_team_average,
+        rank_progress_toward_next_rank=build_rank_progress_chart(rank_progress),
+        team_position_summary=team_position_summary,
+    )
+
+
+def get_sales_advisor_dashboard_overview(
+    session: Session,
+    current_user: AppUser,
+) -> SalesAdvisorDashboardOverviewResponse:
+    validate_sales_advisor(current_user)
+
+    current_points = current_user.points or 0
+    rank_progress = build_rank_progress(current_points)
+
+    team_comparison = None
+    if current_user.manager_user_id is not None:
+        team_members = get_sales_advisor_team_members(
+            session=session,
+            manager_user_id=current_user.manager_user_id,
+        )
+        team_members = ensure_current_user_in_team(current_user, team_members)
+        team_comparison = build_team_comparison(current_user, team_members)
+
+    return SalesAdvisorDashboardOverviewResponse(
+        dashboard_summary=DashboardSummaryResponse(
+            user_id=current_user.user_id,
+            current_points=current_points,
+            current_rank=rank_progress.current_rank,
+            next_rank=rank_progress.next_rank,
+            points_to_next_rank=rank_progress.points_to_next_rank,
+            is_highest_rank=rank_progress.is_highest_rank,
+        ),
+        rank_progress=rank_progress,
+        team_comparison=team_comparison,
+        chart_data=build_chart_data(
+            current_points=current_points,
+            rank_progress=rank_progress,
+            team_comparison=team_comparison,
+        ),
+    )


### PR DESCRIPTION
This endpoint returns the authenticated sales advisor’s current points, rank progress, next rank details, team comparison, and chart-ready dashboard data.

Implemented:

- New sales_advisor_dashboard backend module with router, schemas, service, and repository layers.
- Sales advisor role validation with 403 for non-advisor users.
- Dashboard summary with current points, current rank, next rank, and remaining points.
- Rank progress calculation using existing rank thresholds.
- Team average comparison and team position calculation.
- Chart-ready data for points comparison, rank progress, and team position.