### PR TITLE
Add sales advisor AI analysis endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,9 @@ from app.leaderboard.router import router as leaderboard_router
 from app.AI.summary.manager_router import router as ai_summary_router
 from app.AI.activity_summary.activity_summary_router import router as ai_activity_summary_router
 from app.sales_advisor_dashboard.overview_router import router as sales_advisor_dashboard_router
+from app.sales_advisor_profile.ai_analysis_router import (
+    router as sales_advisor_profile_ai_router,
+)
 
 
 from fastapi.middleware.cors import CORSMiddleware
@@ -39,6 +42,7 @@ app.include_router(account_router)
 app.include_router(ai_summary_router)
 app.include_router(ai_activity_summary_router)
 app.include_router(sales_advisor_dashboard_router)
+app.include_router(sales_advisor_profile_ai_router)
 
 app.include_router(manager_notifications_router)
 

--- a/backend/app/sales_advisor_profile/ai_analysis_repository.py
+++ b/backend/app/sales_advisor_profile/ai_analysis_repository.py
@@ -1,0 +1,75 @@
+from datetime import datetime
+
+from sqlmodel import Session, func, select
+
+from app.models.sale_transaction import SaleTransaction
+from app.models.sale_transaction_item import SaleTransactionItem
+from app.models.user_skill import UserSkill
+from app.sales_advisor_profile.ai_analysis_schemas import (
+    SalesAdvisorRecentPerformanceContext,
+    SalesAdvisorSkillContext,
+)
+
+
+def get_sales_advisor_recent_performance(
+    session: Session,
+    user_id: int,
+    interval_start: datetime | None,
+) -> SalesAdvisorRecentPerformanceContext:
+    conditions = [SaleTransaction.user_id == user_id]
+
+    if interval_start is not None:
+        conditions.append(SaleTransaction.transaction_date >= interval_start)
+
+    sales_result = session.exec(
+        select(
+            func.count(SaleTransaction.transaction_id),
+            func.coalesce(func.sum(SaleTransaction.amount), 0),
+            func.coalesce(func.sum(SaleTransaction.points_earned), 0),
+            func.max(SaleTransaction.transaction_date),
+        ).where(*conditions)
+    ).one()
+
+    total_products_sold = session.exec(
+        select(func.coalesce(func.sum(SaleTransactionItem.quantity), 0))
+        .join(
+            SaleTransaction,
+            SaleTransaction.transaction_id == SaleTransactionItem.transaction_id,
+        )
+        .where(*conditions)
+    ).one()
+
+    return SalesAdvisorRecentPerformanceContext(
+        total_transactions=int(sales_result[0] or 0),
+        total_sales_amount=float(sales_result[1] or 0),
+        total_points_earned=int(sales_result[2] or 0),
+        total_products_sold=int(total_products_sold or 0),
+        last_transaction_date=sales_result[3],
+    )
+
+
+def get_sales_advisor_skills(
+    session: Session,
+    user_id: int,
+) -> list[SalesAdvisorSkillContext]:
+    statement = (
+        select(UserSkill)
+        .where(UserSkill.user_id == user_id)
+        .order_by(
+            UserSkill.verified.desc(),
+            UserSkill.updated_at.desc(),
+            UserSkill.skill_name,
+        )
+    )
+
+    skills = session.exec(statement).all()
+
+    return [
+        SalesAdvisorSkillContext(
+            skill_name=skill.skill_name,
+            skill_level=skill.skill_level,
+            verified=skill.verified,
+            updated_at=skill.updated_at,
+        )
+        for skill in skills
+    ]

--- a/backend/app/sales_advisor_profile/ai_analysis_router.py
+++ b/backend/app/sales_advisor_profile/ai_analysis_router.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends
+from sqlmodel import Session
+
+from app.database import get_session
+from app.manager_statistics.router import get_current_user
+from app.models.app_user import AppUser
+from app.sales_advisor_profile.ai_analysis_schemas import (
+    SalesAdvisorAiAnalysisResponse,
+)
+from app.sales_advisor_profile.ai_analysis_service import (
+    get_sales_advisor_ai_analysis,
+)
+
+
+router = APIRouter(
+    prefix="/api/sales-advisor/profile",
+    tags=["sales-advisor-profile-ai"],
+)
+
+
+@router.get(
+    "/ai-analysis",
+    response_model=SalesAdvisorAiAnalysisResponse,
+    status_code=200,
+)
+def read_sales_advisor_ai_analysis(
+    session: Session = Depends(get_session),
+    current_user: AppUser = Depends(get_current_user),
+):
+    return get_sales_advisor_ai_analysis(
+        session=session,
+        current_user=current_user,
+    )

--- a/backend/app/sales_advisor_profile/ai_analysis_schemas.py
+++ b/backend/app/sales_advisor_profile/ai_analysis_schemas.py
@@ -1,0 +1,100 @@
+from datetime import date, datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+PriorityLevel = Literal["high", "medium", "low"]
+TeamAverageComparison = Literal["above", "below", "equal"]
+
+
+class SalesAdvisorAiStrength(BaseModel):
+    title: str
+    description: str
+    supporting_reason: str
+
+
+class SalesAdvisorAiImprovementArea(BaseModel):
+    title: str
+    description: str
+    reason: str
+    suggested_next_step: str
+    priority: PriorityLevel
+
+
+class SalesAdvisorAiSkillsAnalysis(BaseModel):
+    strong_skills: list[str]
+    skills_to_develop: list[str]
+    summary: str
+
+
+class SalesAdvisorAiAnalysisResponse(BaseModel):
+    ai_summary: str
+    strengths: list[SalesAdvisorAiStrength]
+    improvement_areas: list[SalesAdvisorAiImprovementArea]
+    skills_analysis: SalesAdvisorAiSkillsAnalysis
+    motivational_summary: str
+
+
+class SalesAdvisorProfileContext(BaseModel):
+    user_id: int
+    first_name: str
+    last_name: str
+    email: str
+    phone: str | None = None
+    employee_number: str
+    role: str
+    current_rank: str
+    total_points: int
+    credit: float
+    status: str
+    hire_date: date
+    department_name: str | None = None
+    dealership_name: str | None = None
+    dealer_code: str | None = None
+    city: str | None = None
+    country: str | None = None
+    region: str | None = None
+    manager_name: str | None = None
+
+
+class SalesAdvisorRecentPerformanceContext(BaseModel):
+    interval_label: str = "last_30_days"
+    total_transactions: int
+    total_sales_amount: float
+    total_points_earned: int
+    total_products_sold: int
+    last_transaction_date: datetime | None
+
+
+class SalesAdvisorSkillContext(BaseModel):
+    skill_name: str
+    skill_level: str
+    verified: bool
+    updated_at: datetime
+
+
+class SalesAdvisorRankProgressContext(BaseModel):
+    current_rank: str
+    next_rank: str | None
+    current_points: int
+    points_to_next_rank: int | None
+    progress_percentage: float
+    is_highest_rank: bool
+
+
+class SalesAdvisorTeamComparisonContext(BaseModel):
+    team_average_points: float
+    comparison_to_team_average: TeamAverageComparison
+    points_difference_from_average: float
+    team_position: int
+    total_sales_advisors: int
+
+
+class SalesAdvisorAiAnalysisContext(BaseModel):
+    profile: SalesAdvisorProfileContext
+    recent_performance: SalesAdvisorRecentPerformanceContext
+    rank_progress: SalesAdvisorRankProgressContext
+    team_comparison: SalesAdvisorTeamComparisonContext | None = None
+    skills: list[SalesAdvisorSkillContext] = Field(default_factory=list)
+    missing_data: list[str] = Field(default_factory=list)

--- a/backend/app/sales_advisor_profile/ai_analysis_service.py
+++ b/backend/app/sales_advisor_profile/ai_analysis_service.py
@@ -1,0 +1,646 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+from sqlmodel import Session
+
+from app.account.account_repository import get_current_user_profile_row
+from app.models.app_user import AppUser
+from app.sales_advisor_dashboard.overview_repository import (
+    get_sales_advisor_team_members,
+)
+from app.sales_advisor_dashboard.overview_service import (
+    build_rank_progress,
+    build_team_comparison,
+    ensure_current_user_in_team,
+    validate_sales_advisor,
+)
+from app.sales_advisor_profile.ai_analysis_repository import (
+    get_sales_advisor_recent_performance,
+    get_sales_advisor_skills,
+)
+from app.sales_advisor_profile.ai_analysis_schemas import (
+    SalesAdvisorAiAnalysisContext,
+    SalesAdvisorAiAnalysisResponse,
+    SalesAdvisorAiImprovementArea,
+    SalesAdvisorAiSkillsAnalysis,
+    SalesAdvisorAiStrength,
+    SalesAdvisorProfileContext,
+    SalesAdvisorRankProgressContext,
+    SalesAdvisorTeamComparisonContext,
+)
+
+
+RECENT_PERFORMANCE_DAYS = 30
+AI_MODEL = "gpt-4.1-mini"
+
+
+def _get_recent_performance_start() -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=RECENT_PERFORMANCE_DAYS)
+
+
+def _dedupe_keep_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+
+    for value in values:
+        normalized = value.strip()
+        if not normalized:
+            continue
+        key = normalized.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(normalized)
+
+    return result
+
+
+def _skill_names_for_levels(
+    context: SalesAdvisorAiAnalysisContext,
+    *,
+    levels: set[str],
+    verified_only: bool = False,
+) -> list[str]:
+    return _dedupe_keep_order(
+        [
+            skill.skill_name
+            for skill in context.skills
+            if skill.skill_level.lower() in levels
+            and (skill.verified if verified_only else True)
+        ]
+    )
+
+
+def _build_profile_context(
+    session: Session,
+    current_user: AppUser,
+) -> SalesAdvisorProfileContext:
+    row = get_current_user_profile_row(session, current_user.user_id)
+
+    if row is None:
+        return SalesAdvisorProfileContext(
+            user_id=current_user.user_id,
+            first_name=current_user.first_name,
+            last_name=current_user.last_name,
+            email=current_user.email,
+            phone=current_user.phone,
+            employee_number=current_user.employee_number,
+            role=current_user.role,
+            current_rank=current_user.rank,
+            total_points=current_user.points or 0,
+            credit=float(current_user.credit or 0),
+            status=current_user.status,
+            hire_date=current_user.hire_date,
+        )
+
+    (
+        user,
+        department_id,
+        department_name,
+        dealership_id,
+        dealership_name,
+        dealer_code,
+        city,
+        country,
+        region,
+        manager_user_id,
+        manager_first_name,
+        manager_last_name,
+        _manager_email,
+    ) = row
+
+    manager_name = None
+    if manager_user_id is not None:
+        manager_name = " ".join(
+            [part for part in [manager_first_name, manager_last_name] if part]
+        )
+
+    return SalesAdvisorProfileContext(
+        user_id=user.user_id,
+        first_name=user.first_name,
+        last_name=user.last_name,
+        email=user.email,
+        phone=user.phone,
+        employee_number=user.employee_number,
+        role=user.role,
+        current_rank=user.rank,
+        total_points=user.points or 0,
+        credit=float(user.credit or 0),
+        status=user.status,
+        hire_date=user.hire_date,
+        department_name=department_name if department_id is not None else None,
+        dealership_name=dealership_name if dealership_id is not None else None,
+        dealer_code=dealer_code,
+        city=city,
+        country=country,
+        region=region,
+        manager_name=manager_name or None,
+    )
+
+
+def build_sales_advisor_ai_analysis_context(
+    session: Session,
+    current_user: AppUser,
+) -> SalesAdvisorAiAnalysisContext:
+    validate_sales_advisor(current_user)
+
+    profile = _build_profile_context(session, current_user)
+    recent_performance = get_sales_advisor_recent_performance(
+        session=session,
+        user_id=current_user.user_id,
+        interval_start=_get_recent_performance_start(),
+    )
+
+    rank_progress = build_rank_progress(profile.total_points)
+    skills = get_sales_advisor_skills(session, current_user.user_id)
+
+    team_comparison = None
+    if current_user.manager_user_id is not None:
+        team_members = get_sales_advisor_team_members(
+            session=session,
+            manager_user_id=current_user.manager_user_id,
+        )
+        team_members = ensure_current_user_in_team(current_user, team_members)
+        comparison = build_team_comparison(current_user, team_members)
+        team_comparison = SalesAdvisorTeamComparisonContext(**comparison.model_dump())
+
+    missing_data: list[str] = []
+    if recent_performance.total_transactions == 0:
+        missing_data.append(
+            "No recent sales transactions were found for the last 30 days."
+        )
+    if not skills:
+        missing_data.append("No skill records are available for this advisor.")
+    if team_comparison is None:
+        missing_data.append(
+            "Team comparison data is unavailable because the advisor is not linked to a manager team."
+        )
+
+    return SalesAdvisorAiAnalysisContext(
+        profile=profile,
+        recent_performance=recent_performance,
+        rank_progress=SalesAdvisorRankProgressContext(
+            current_rank=rank_progress.current_rank,
+            next_rank=rank_progress.next_rank,
+            current_points=rank_progress.current_points,
+            points_to_next_rank=rank_progress.points_to_next_rank,
+            progress_percentage=rank_progress.progress_percentage,
+            is_highest_rank=rank_progress.is_highest_rank,
+        ),
+        team_comparison=team_comparison,
+        skills=skills,
+        missing_data=missing_data,
+    )
+
+
+def build_sales_advisor_ai_prompt(payload: SalesAdvisorAiAnalysisContext) -> str:
+    data = payload.model_dump(mode="json")
+
+    return f"""
+You are generating an AI performance analysis for a sales advisor viewing their own profile.
+
+Return only valid JSON. Do not add markdown, explanations, or code fences.
+
+Required JSON structure:
+{{
+  "ai_summary": "string",
+  "strengths": [
+    {{
+      "title": "string",
+      "description": "string",
+      "supporting_reason": "string"
+    }}
+  ],
+  "improvement_areas": [
+    {{
+      "title": "string",
+      "description": "string",
+      "reason": "string",
+      "suggested_next_step": "string",
+      "priority": "high|medium|low"
+    }}
+  ],
+  "skills_analysis": {{
+    "strong_skills": ["string"],
+    "skills_to_develop": ["string"],
+    "summary": "string"
+  }},
+  "motivational_summary": "string"
+}}
+
+Rules:
+- Use only the data provided below.
+- Do not invent metrics, trends, comparisons, skill ratings, or achievements.
+- Write in an encouraging, constructive, advisor-friendly tone.
+- Be clear and concrete whenever data exists.
+- If data is missing, say what is missing instead of guessing.
+- Every strength must include a short explanation and a supporting reason.
+- Every improvement area must include a reason, a suggested next step, and a priority.
+- Skills analysis must clearly state if skill data is missing or incomplete.
+- The motivational summary must be short, realistic, and personalized.
+- Return 1 to 3 strengths.
+- Return 1 to 3 improvement areas.
+
+Advisor performance context:
+{json.dumps(data, indent=2)}
+"""
+
+
+def _extract_json_payload(raw_text: str) -> dict:
+    text = raw_text.strip()
+
+    if text.startswith("```"):
+        lines = text.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].startswith("```"):
+            lines = lines[:-1]
+        text = "\n".join(lines).strip()
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        start = text.find("{")
+        end = text.rfind("}")
+        if start == -1 or end == -1 or end <= start:
+            raise
+        return json.loads(text[start : end + 1])
+
+
+def generate_sales_advisor_ai_analysis_with_ai(
+    payload: SalesAdvisorAiAnalysisContext,
+) -> SalesAdvisorAiAnalysisResponse:
+    try:
+        from openai import OpenAI
+    except Exception as exc:
+        raise RuntimeError("OpenAI SDK unavailable") from exc
+
+    client = OpenAI()
+    response = client.responses.create(
+        model=AI_MODEL,
+        input=build_sales_advisor_ai_prompt(payload),
+        temperature=0.4,
+        max_output_tokens=900,
+    )
+
+    response_text = (response.output_text or "").strip()
+    if not response_text:
+        raise ValueError("Empty AI response")
+
+    parsed = _extract_json_payload(response_text)
+    analysis = SalesAdvisorAiAnalysisResponse.model_validate(parsed)
+    return merge_ai_analysis_with_fallback(analysis, payload)
+
+
+def _build_recent_performance_sentence(
+    payload: SalesAdvisorAiAnalysisContext,
+) -> str:
+    recent = payload.recent_performance
+
+    if recent.total_transactions == 0:
+        return (
+            "No recent sales transactions were recorded in the last 30 days, so the current view of performance is limited."
+        )
+
+    last_transaction_text = ""
+    if recent.last_transaction_date is not None:
+        last_transaction_text = (
+            f" The latest recorded transaction was on {recent.last_transaction_date:%d %b %Y}."
+        )
+
+    return (
+        f"In the last 30 days you recorded {recent.total_transactions} transactions, "
+        f"generated EUR {recent.total_sales_amount:,.2f} in sales, sold "
+        f"{recent.total_products_sold} products, and earned {recent.total_points_earned} points."
+        f"{last_transaction_text}"
+    )
+
+
+def _build_team_comparison_sentence(
+    payload: SalesAdvisorAiAnalysisContext,
+) -> str:
+    team_comparison = payload.team_comparison
+    if team_comparison is None:
+        return "Team comparison data is not available right now."
+
+    difference = abs(team_comparison.points_difference_from_average)
+
+    if team_comparison.comparison_to_team_average == "above":
+        return (
+            f"You are currently above the team average by {difference:,.0f} points and hold position "
+            f"{team_comparison.team_position} out of {team_comparison.total_sales_advisors} advisors."
+        )
+
+    if team_comparison.comparison_to_team_average == "below":
+        return (
+            f"You are currently {difference:,.0f} points below the team average and hold position "
+            f"{team_comparison.team_position} out of {team_comparison.total_sales_advisors} advisors."
+        )
+
+    return (
+        f"You are currently aligned with the team average and hold position {team_comparison.team_position} "
+        f"out of {team_comparison.total_sales_advisors} advisors."
+    )
+
+
+def _build_fallback_strengths(
+    payload: SalesAdvisorAiAnalysisContext,
+) -> list[SalesAdvisorAiStrength]:
+    strengths: list[SalesAdvisorAiStrength] = []
+    strong_skills = _skill_names_for_levels(
+        payload,
+        levels={"advanced"},
+        verified_only=False,
+    )
+
+    if payload.team_comparison is not None and (
+        payload.team_comparison.comparison_to_team_average == "above"
+    ):
+        strengths.append(
+            SalesAdvisorAiStrength(
+                title="Above team average",
+                description=(
+                    "Your current points place you above the average level of your team."
+                ),
+                supporting_reason=(
+                    f"You have {payload.profile.total_points} points, which is "
+                    f"{payload.team_comparison.points_difference_from_average:,.0f} points above the team average."
+                ),
+            )
+        )
+
+    if strong_skills:
+        strengths.append(
+            SalesAdvisorAiStrength(
+                title="Strong skill foundation",
+                description=(
+                    f"You already show strong capability in {', '.join(strong_skills[:3])}."
+                ),
+                supporting_reason=(
+                    "These skills are recorded at an advanced level in your profile data."
+                ),
+            )
+        )
+
+    if payload.recent_performance.total_transactions > 0:
+        strengths.append(
+            SalesAdvisorAiStrength(
+                title="Visible recent activity",
+                description=(
+                    "You have recent sales activity that can be used as a concrete base for coaching and progress tracking."
+                ),
+                supporting_reason=(
+                    f"The last 30 days include {payload.recent_performance.total_transactions} transactions, "
+                    f"{payload.recent_performance.total_products_sold} products sold, and "
+                    f"{payload.recent_performance.total_points_earned} points earned."
+                ),
+            )
+        )
+
+    if not strengths:
+        strengths.append(
+            SalesAdvisorAiStrength(
+                title="More performance data is needed",
+                description=(
+                    "There is not enough recent or comparative data yet to identify clear strengths with confidence."
+                ),
+                supporting_reason=(
+                    "Recent activity, skills data, or team comparison details are limited or unavailable."
+                ),
+            )
+        )
+
+    return strengths[:3]
+
+
+def _build_fallback_improvement_areas(
+    payload: SalesAdvisorAiAnalysisContext,
+) -> list[SalesAdvisorAiImprovementArea]:
+    areas: list[SalesAdvisorAiImprovementArea] = []
+    skills_to_develop = _skill_names_for_levels(
+        payload,
+        levels={"beginner"},
+        verified_only=False,
+    )
+
+    if payload.recent_performance.total_transactions == 0:
+        areas.append(
+            SalesAdvisorAiImprovementArea(
+                title="Build recent sales momentum",
+                description=(
+                    "Your recent sales activity is too limited to show a clear short-term performance pattern."
+                ),
+                reason=(
+                    "No transactions were recorded in the last 30 days."
+                ),
+                suggested_next_step=(
+                    "Focus on creating a short list of active opportunities and aim to close at least one sale this week."
+                ),
+                priority="high",
+            )
+        )
+
+    if payload.team_comparison is not None and (
+        payload.team_comparison.comparison_to_team_average == "below"
+    ):
+        difference = abs(payload.team_comparison.points_difference_from_average)
+        areas.append(
+            SalesAdvisorAiImprovementArea(
+                title="Close the gap to team average",
+                description=(
+                    "A focused improvement plan would help you move closer to the current pace of your team."
+                ),
+                reason=(
+                    f"You are currently {difference:,.0f} points below the team average."
+                ),
+                suggested_next_step=(
+                    "Set a short-term weekly target for transactions or points and review progress with your manager."
+                ),
+                priority="high",
+            )
+        )
+
+    if skills_to_develop:
+        areas.append(
+            SalesAdvisorAiImprovementArea(
+                title="Develop selected skills",
+                description=(
+                    f"The next growth opportunity is to strengthen {', '.join(skills_to_develop[:3])}."
+                ),
+                reason=(
+                    "These skills are currently recorded at a beginner level."
+                ),
+                suggested_next_step=(
+                    "Choose one of these skills and practice it intentionally during your next customer interactions."
+                ),
+                priority="medium",
+            )
+        )
+
+    if (
+        payload.rank_progress.points_to_next_rank is not None
+        and payload.rank_progress.points_to_next_rank > 0
+    ):
+        areas.append(
+            SalesAdvisorAiImprovementArea(
+                title="Work toward the next rank",
+                description=(
+                    "A steady focus on points and sales activity would move you closer to the next rank milestone."
+                ),
+                reason=(
+                    f"You still need {payload.rank_progress.points_to_next_rank} points to reach {payload.rank_progress.next_rank}."
+                ),
+                suggested_next_step=(
+                    "Break the remaining points into a weekly target so the next rank feels achievable."
+                ),
+                priority="medium",
+            )
+        )
+
+    if not areas:
+        areas.append(
+            SalesAdvisorAiImprovementArea(
+                title="More data is needed for targeted coaching",
+                description=(
+                    "There is not enough recent or comparative information to point to one evidence-based improvement area yet."
+                ),
+                reason=(
+                    "Recent activity, team comparison, and skill-development signals are limited."
+                ),
+                suggested_next_step=(
+                    "Keep your activity and skill records updated so future analysis can be more specific."
+                ),
+                priority="low",
+            )
+        )
+
+    return areas[:3]
+
+
+def _build_fallback_skills_analysis(
+    payload: SalesAdvisorAiAnalysisContext,
+) -> SalesAdvisorAiSkillsAnalysis:
+    if not payload.skills:
+        return SalesAdvisorAiSkillsAnalysis(
+            strong_skills=[],
+            skills_to_develop=[],
+            summary=(
+                "Skill data is currently unavailable, so your skills could not be fully evaluated."
+            ),
+        )
+
+    strong_skills = _skill_names_for_levels(
+        payload,
+        levels={"advanced"},
+        verified_only=False,
+    )[:3]
+    skills_to_develop = _skill_names_for_levels(
+        payload,
+        levels={"beginner"},
+        verified_only=False,
+    )[:3]
+
+    if strong_skills and skills_to_develop:
+        summary = (
+            f"You already show strength in {', '.join(strong_skills)}, and the clearest development opportunities are "
+            f"{', '.join(skills_to_develop)}."
+        )
+    elif strong_skills:
+        summary = (
+            f"Your profile shows clear strength in {', '.join(strong_skills)}. More recent skill updates would help identify the next development priorities."
+        )
+    elif skills_to_develop:
+        summary = (
+            f"Current skill records suggest a need to focus on {', '.join(skills_to_develop)}. Stronger skill evidence is still limited."
+        )
+    else:
+        summary = (
+            "Skill records exist, but they do not yet show a clear split between strong areas and development needs."
+        )
+
+    return SalesAdvisorAiSkillsAnalysis(
+        strong_skills=strong_skills,
+        skills_to_develop=skills_to_develop,
+        summary=summary,
+    )
+
+
+def build_fallback_sales_advisor_ai_analysis(
+    payload: SalesAdvisorAiAnalysisContext,
+    *,
+    ai_unavailable: bool,
+) -> SalesAdvisorAiAnalysisResponse:
+    prefix = (
+        "AI analysis is temporarily unavailable. "
+        if ai_unavailable
+        else ""
+    )
+
+    ai_summary = (
+        prefix
+        + f"You are currently ranked {payload.profile.current_rank} with {payload.profile.total_points} points. "
+        + _build_recent_performance_sentence(payload)
+        + " "
+        + _build_team_comparison_sentence(payload)
+    ).strip()
+
+    if payload.rank_progress.is_highest_rank:
+        motivational_summary = (
+            "You have already reached the top rank. Keep your consistency high and use your strongest habits to maintain that position."
+        )
+    elif payload.rank_progress.points_to_next_rank is not None:
+        motivational_summary = (
+            f"You have a clear next milestone ahead: {payload.rank_progress.points_to_next_rank} more points to reach {payload.rank_progress.next_rank}. "
+            "Stay consistent and focus on the next practical step."
+        )
+    else:
+        motivational_summary = (
+            "You have a solid base to build on. Keep your focus on the next practical improvement and your progress will become easier to track."
+        )
+
+    return SalesAdvisorAiAnalysisResponse(
+        ai_summary=ai_summary,
+        strengths=_build_fallback_strengths(payload),
+        improvement_areas=_build_fallback_improvement_areas(payload),
+        skills_analysis=_build_fallback_skills_analysis(payload),
+        motivational_summary=motivational_summary,
+    )
+
+
+def merge_ai_analysis_with_fallback(
+    analysis: SalesAdvisorAiAnalysisResponse,
+    payload: SalesAdvisorAiAnalysisContext,
+) -> SalesAdvisorAiAnalysisResponse:
+    fallback = build_fallback_sales_advisor_ai_analysis(
+        payload,
+        ai_unavailable=False,
+    )
+
+    return SalesAdvisorAiAnalysisResponse(
+        ai_summary=analysis.ai_summary.strip() or fallback.ai_summary,
+        strengths=analysis.strengths or fallback.strengths,
+        improvement_areas=analysis.improvement_areas or fallback.improvement_areas,
+        skills_analysis=(
+            analysis.skills_analysis
+            if analysis.skills_analysis.summary.strip()
+            else fallback.skills_analysis
+        ),
+        motivational_summary=(
+            analysis.motivational_summary.strip() or fallback.motivational_summary
+        ),
+    )
+
+
+def get_sales_advisor_ai_analysis(
+    session: Session,
+    current_user: AppUser,
+) -> SalesAdvisorAiAnalysisResponse:
+    payload = build_sales_advisor_ai_analysis_context(session, current_user)
+
+    try:
+        return generate_sales_advisor_ai_analysis_with_ai(payload)
+    except Exception:
+        return build_fallback_sales_advisor_ai_analysis(
+            payload,
+            ai_unavailable=True,
+        )


### PR DESCRIPTION
Implement GET /api/sales-advisor/profile/ai-analysis for authenticated sales advisors. 
Add schemas, repository, service, and router, collect advisor profile, points, rank, recent performance, skills, and team comparison data, and return a complete fallback response when AI is unavailable.