### PR TITLE
[Backend] Add Sales Advisor dashboard charts and leaderboard endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,12 @@ from app.leaderboard.router import router as leaderboard_router
 from app.AI.summary.manager_router import router as ai_summary_router
 from app.AI.activity_summary.activity_summary_router import router as ai_activity_summary_router
 from app.sales_advisor_dashboard.overview_router import router as sales_advisor_dashboard_router
+from app.sales_advisor_leaderboard.leaderboard_router import (
+    router as sales_advisor_leaderboard_router,
+)
+from app.sales_advisor_performance_charts.performance_charts_router import (
+    router as sales_advisor_performance_charts_router,
+)
 
 
 from fastapi.middleware.cors import CORSMiddleware
@@ -39,6 +45,8 @@ app.include_router(account_router)
 app.include_router(ai_summary_router)
 app.include_router(ai_activity_summary_router)
 app.include_router(sales_advisor_dashboard_router)
+app.include_router(sales_advisor_leaderboard_router)
+app.include_router(sales_advisor_performance_charts_router)
 
 app.include_router(manager_notifications_router)
 

--- a/backend/app/sales_advisor_leaderboard/leaderboard_repository.py
+++ b/backend/app/sales_advisor_leaderboard/leaderboard_repository.py
@@ -1,0 +1,22 @@
+from sqlmodel import Session, select
+
+from app.models.app_user import AppUser
+
+
+def get_global_sales_advisors(session: Session) -> list[AppUser]:
+    statement = select(AppUser).where(AppUser.role.ilike("sales_advisor"))
+
+    return list(session.exec(statement).all())
+
+
+def get_team_sales_advisors(
+    session: Session,
+    manager_user_id: int | None,
+) -> list[AppUser]:
+    statement = (
+        select(AppUser)
+        .where(AppUser.manager_user_id == manager_user_id)
+        .where(AppUser.role.ilike("sales_advisor"))
+    )
+
+    return list(session.exec(statement).all())

--- a/backend/app/sales_advisor_leaderboard/leaderboard_router.py
+++ b/backend/app/sales_advisor_leaderboard/leaderboard_router.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Depends, Query
+from sqlmodel import Session
+
+from app.database import get_session
+from app.manager_statistics.router import get_current_user
+from app.models.app_user import AppUser
+from app.sales_advisor_leaderboard.leaderboard_schemas import (
+    SalesAdvisorLeaderboardResponse,
+)
+from app.sales_advisor_leaderboard.leaderboard_service import (
+    get_sales_advisor_leaderboard,
+)
+
+
+router = APIRouter(
+    prefix="/api/sales-advisor",
+    tags=["sales-advisor-leaderboard"],
+)
+
+
+@router.get(
+    "/leaderboard",
+    response_model=SalesAdvisorLeaderboardResponse,
+    status_code=200,
+)
+def read_sales_advisor_leaderboard(
+    scope: str = Query(default="team"),
+    limit: str = Query(default="10"),
+    session: Session = Depends(get_session),
+    current_user: AppUser = Depends(get_current_user),
+):
+    return get_sales_advisor_leaderboard(
+        session=session,
+        current_user=current_user,
+        scope=scope,
+        limit=limit,
+    )

--- a/backend/app/sales_advisor_leaderboard/leaderboard_schemas.py
+++ b/backend/app/sales_advisor_leaderboard/leaderboard_schemas.py
@@ -1,0 +1,20 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+LeaderboardScope = Literal["team", "global"]
+
+
+class SalesAdvisorLeaderboardEntry(BaseModel):
+    position: int
+    first_name: str
+    last_name: str
+    points: int
+    rank: str
+
+
+class SalesAdvisorLeaderboardResponse(BaseModel):
+    leaderboard_list: list[SalesAdvisorLeaderboardEntry]
+    current_user_position: int | None
+    current_user: SalesAdvisorLeaderboardEntry | None

--- a/backend/app/sales_advisor_leaderboard/leaderboard_service.py
+++ b/backend/app/sales_advisor_leaderboard/leaderboard_service.py
@@ -1,0 +1,141 @@
+from fastapi import HTTPException
+from sqlmodel import Session
+
+from app.models.app_user import AppUser
+from app.sales_advisor_dashboard.overview_service import validate_sales_advisor
+from app.sales_advisor_leaderboard.leaderboard_repository import (
+    get_global_sales_advisors,
+    get_team_sales_advisors,
+)
+from app.sales_advisor_leaderboard.leaderboard_schemas import (
+    LeaderboardScope,
+    SalesAdvisorLeaderboardEntry,
+    SalesAdvisorLeaderboardResponse,
+)
+
+
+VALID_LEADERBOARD_SCOPES: set[LeaderboardScope] = {"team", "global"}
+MIN_LEADERBOARD_LIMIT = 1
+
+
+def ensure_current_user_in_leaderboard(
+    current_user: AppUser,
+    advisors: list[AppUser],
+) -> list[AppUser]:
+    if any(advisor.user_id == current_user.user_id for advisor in advisors):
+        return advisors
+
+    return [*advisors, current_user]
+
+
+def sort_advisors_for_ranking(advisors: list[AppUser]) -> list[AppUser]:
+    return sorted(
+        advisors,
+        key=lambda advisor: (
+            -(advisor.points or 0),
+            (advisor.last_name or "").lower(),
+            (advisor.first_name or "").lower(),
+            advisor.user_id or 0,
+        ),
+    )
+
+
+def build_leaderboard_entry(
+    advisor: AppUser,
+    position: int,
+) -> SalesAdvisorLeaderboardEntry:
+    return SalesAdvisorLeaderboardEntry(
+        position=position,
+        first_name=advisor.first_name,
+        last_name=advisor.last_name,
+        points=advisor.points or 0,
+        rank=advisor.rank,
+    )
+
+
+def normalize_leaderboard_scope(scope: str) -> LeaderboardScope:
+    normalized_scope = scope.strip().lower()
+
+    if normalized_scope not in VALID_LEADERBOARD_SCOPES:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid scope. Use team or global.",
+        )
+
+    return normalized_scope
+
+
+def normalize_leaderboard_limit(limit: str | int) -> int:
+    try:
+        normalized_limit = int(limit)
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid limit. Use a positive integer.",
+        )
+
+    if str(limit).strip() != str(normalized_limit):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid limit. Use a positive integer.",
+        )
+
+    if normalized_limit < MIN_LEADERBOARD_LIMIT:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid limit. Limit must be greater than 0.",
+        )
+
+    return normalized_limit
+
+
+def get_sales_advisor_leaderboard(
+    session: Session,
+    current_user: AppUser,
+    scope: str,
+    limit: str | int,
+) -> SalesAdvisorLeaderboardResponse:
+    validate_sales_advisor(current_user)
+    normalized_scope = normalize_leaderboard_scope(scope)
+    normalized_limit = normalize_leaderboard_limit(limit)
+
+    if normalized_scope == "global":
+        advisors = get_global_sales_advisors(session=session)
+    else:
+        advisors = get_team_sales_advisors(
+            session=session,
+            manager_user_id=current_user.manager_user_id,
+        )
+
+    advisors = ensure_current_user_in_leaderboard(current_user, advisors)
+    ranked_advisors = sort_advisors_for_ranking(advisors)
+
+    position_by_user_id = {
+        advisor.user_id: position
+        for position, advisor in enumerate(ranked_advisors, start=1)
+    }
+    top_advisors = ranked_advisors[:normalized_limit]
+    leaderboard_list = [
+        build_leaderboard_entry(
+            advisor=advisor,
+            position=position_by_user_id[advisor.user_id],
+        )
+        for advisor in top_advisors
+    ]
+
+    current_user_position = position_by_user_id.get(current_user.user_id)
+    current_user_entry = None
+
+    if current_user_position is not None and not any(
+        advisor.user_id == current_user.user_id for advisor in top_advisors
+    ):
+        current_user_entry = build_leaderboard_entry(
+            advisor=current_user,
+            position=current_user_position,
+        )
+
+    return SalesAdvisorLeaderboardResponse(
+        leaderboard_list=leaderboard_list,
+        current_user_position=current_user_position,
+        current_user=current_user_entry,
+    )

--- a/backend/app/sales_advisor_performance_charts/performance_charts_repository.py
+++ b/backend/app/sales_advisor_performance_charts/performance_charts_repository.py
@@ -1,0 +1,35 @@
+from sqlmodel import Session, select
+
+from app.models.app_user import AppUser
+from app.models.sale_transaction import SaleTransaction
+
+
+def get_completed_sales_transactions_for_advisor(
+    session: Session,
+    user_id: int,
+):
+    statement = (
+        select(
+            SaleTransaction.transaction_date,
+            SaleTransaction.amount,
+            SaleTransaction.points_earned,
+        )
+        .where(SaleTransaction.user_id == user_id)
+        .where(SaleTransaction.status.ilike("completed"))
+        .order_by(SaleTransaction.transaction_date)
+    )
+
+    return list(session.exec(statement).all())
+
+
+def get_sales_advisor_team_members(
+    session: Session,
+    manager_user_id: int,
+) -> list[AppUser]:
+    statement = (
+        select(AppUser)
+        .where(AppUser.manager_user_id == manager_user_id)
+        .where(AppUser.role.ilike("sales_advisor"))
+    )
+
+    return list(session.exec(statement).all())

--- a/backend/app/sales_advisor_performance_charts/performance_charts_router.py
+++ b/backend/app/sales_advisor_performance_charts/performance_charts_router.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, Depends, Header, HTTPException
+from sqlmodel import Session
+
+from app.database import get_session
+from app.models.app_user import AppUser
+from app.sales_advisor_performance_charts.performance_charts_schemas import (
+    SalesAdvisorPerformanceChartsResponse,
+)
+from app.sales_advisor_performance_charts.performance_charts_service import (
+    get_sales_advisor_performance_charts,
+)
+
+
+def get_current_user_for_performance_charts(
+    x_user_id: str | None = Header(default=None),
+    session: Session = Depends(get_session),
+) -> AppUser:
+    if x_user_id is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    try:
+        user_id = int(x_user_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid request.")
+
+    user = session.get(AppUser, user_id)
+
+    if user is None:
+        raise HTTPException(status_code=401, detail="Invalid user ID")
+
+    return user
+
+
+router = APIRouter(
+    prefix="/api/sales-advisor/dashboard",
+    tags=["sales-advisor-performance-charts"],
+)
+
+
+@router.get(
+    "/charts",
+    response_model=SalesAdvisorPerformanceChartsResponse,
+    status_code=200,
+)
+def read_sales_advisor_performance_charts(
+    session: Session = Depends(get_session),
+    current_user: AppUser = Depends(get_current_user_for_performance_charts),
+):
+    return get_sales_advisor_performance_charts(
+        session=session,
+        current_user=current_user,
+    )

--- a/backend/app/sales_advisor_performance_charts/performance_charts_schemas.py
+++ b/backend/app/sales_advisor_performance_charts/performance_charts_schemas.py
@@ -1,0 +1,73 @@
+from pydantic import BaseModel
+
+
+class ChartSectionBase(BaseModel):
+    is_available: bool
+    unavailable_reason: str | None
+    labels: list[str]
+    values: list[float]
+
+
+class PersonalPerformanceChartPoint(BaseModel):
+    label: str
+    value: float
+    period: str
+    sales: float
+    points: int
+    transaction_count: int
+
+
+class PersonalPerformanceChartSection(ChartSectionBase):
+    data: list[PersonalPerformanceChartPoint]
+    value_unit: str = "points"
+    secondary_value_unit: str = "sales"
+
+
+class PointsComparisonChartPoint(BaseModel):
+    label: str
+    value: float
+
+
+class PersonalVsTeamAverageChartSection(ChartSectionBase):
+    data: list[PointsComparisonChartPoint]
+    value_unit: str = "points"
+
+
+class RankProgressChartPoint(BaseModel):
+    label: str
+    value: float
+
+
+class RankProgressChartSection(ChartSectionBase):
+    data: list[RankProgressChartPoint]
+    current_rank: str
+    next_rank: str | None
+    current_points: int
+    start_points: int
+    target_points: int | None
+    remaining_points: int | None
+    progress_percentage: float
+    is_highest_rank: bool
+    value_unit: str = "percentage"
+
+
+class TeamPositionChartPoint(BaseModel):
+    label: str
+    value: float
+
+
+class TeamPositionChartSection(ChartSectionBase):
+    data: list[TeamPositionChartPoint]
+    team_position: int | None
+    total_sales_advisors: int | None
+    advisors_ahead: int | None
+    advisors_behind: int | None
+    value_unit: str = "advisors"
+
+
+class SalesAdvisorPerformanceChartsResponse(BaseModel):
+    user_id: int
+    personal_performance: PersonalPerformanceChartSection
+    personal_vs_team_average: PersonalVsTeamAverageChartSection
+    rank_progress: RankProgressChartSection
+    team_position: TeamPositionChartSection

--- a/backend/app/sales_advisor_performance_charts/performance_charts_service.py
+++ b/backend/app/sales_advisor_performance_charts/performance_charts_service.py
@@ -1,0 +1,252 @@
+from sqlmodel import Session
+
+from app.models.app_user import AppUser
+from app.sales_advisor_dashboard.overview_service import (
+    build_rank_progress,
+    build_team_comparison,
+    ensure_current_user_in_team,
+    validate_sales_advisor,
+)
+from app.sales_advisor_performance_charts.performance_charts_repository import (
+    get_completed_sales_transactions_for_advisor,
+    get_sales_advisor_team_members,
+)
+from app.sales_advisor_performance_charts.performance_charts_schemas import (
+    PersonalPerformanceChartPoint,
+    PersonalPerformanceChartSection,
+    PersonalVsTeamAverageChartSection,
+    PointsComparisonChartPoint,
+    RankProgressChartPoint,
+    RankProgressChartSection,
+    SalesAdvisorPerformanceChartsResponse,
+    TeamPositionChartPoint,
+    TeamPositionChartSection,
+)
+
+
+NO_PERSONAL_PERFORMANCE_DATA = (
+    "Not enough completed sales data is available for the personal performance chart."
+)
+TEAM_DATA_UNAVAILABLE = "Team data unavailable: advisor is not assigned to a manager."
+
+
+def build_personal_performance_chart(
+    transactions,
+) -> PersonalPerformanceChartSection:
+    if not transactions:
+        return PersonalPerformanceChartSection(
+            is_available=False,
+            unavailable_reason=NO_PERSONAL_PERFORMANCE_DATA,
+            labels=[],
+            values=[],
+            data=[],
+        )
+
+    grouped: dict[str, dict[str, float | int]] = {}
+
+    for transaction_date, amount, points_earned in transactions:
+        period = transaction_date.date().isoformat()
+
+        if period not in grouped:
+            grouped[period] = {
+                "sales": 0.0,
+                "points": 0,
+                "transaction_count": 0,
+            }
+
+        grouped[period]["sales"] = float(grouped[period]["sales"]) + float(amount or 0)
+        grouped[period]["points"] = int(grouped[period]["points"]) + int(
+            points_earned or 0
+        )
+        grouped[period]["transaction_count"] = int(
+            grouped[period]["transaction_count"]
+        ) + 1
+
+    data = [
+        PersonalPerformanceChartPoint(
+            label=period,
+            value=float(values["points"]),
+            period=period,
+            sales=round(float(values["sales"]), 2),
+            points=int(values["points"]),
+            transaction_count=int(values["transaction_count"]),
+        )
+        for period, values in grouped.items()
+    ]
+
+    return PersonalPerformanceChartSection(
+        is_available=True,
+        unavailable_reason=None,
+        labels=[point.label for point in data],
+        values=[point.value for point in data],
+        data=data,
+    )
+
+
+def build_personal_vs_team_average_chart(
+    current_points: int,
+    team_average_points: float | None,
+    unavailable_reason: str | None,
+) -> PersonalVsTeamAverageChartSection:
+    if team_average_points is None:
+        return PersonalVsTeamAverageChartSection(
+            is_available=False,
+            unavailable_reason=unavailable_reason,
+            labels=[],
+            values=[],
+            data=[],
+        )
+
+    data = [
+        PointsComparisonChartPoint(
+            label="Personal",
+            value=float(current_points),
+        ),
+        PointsComparisonChartPoint(
+            label="Team average",
+            value=round(team_average_points, 2),
+        ),
+    ]
+
+    return PersonalVsTeamAverageChartSection(
+        is_available=True,
+        unavailable_reason=None,
+        labels=[point.label for point in data],
+        values=[point.value for point in data],
+        data=data,
+    )
+
+
+def build_rank_progress_chart(current_points: int) -> RankProgressChartSection:
+    rank_progress = build_rank_progress(current_points)
+
+    if rank_progress.is_highest_rank:
+        data = [
+            RankProgressChartPoint(
+                label="Progress",
+                value=100.0,
+            )
+        ]
+    else:
+        remaining_percentage = round(100.0 - rank_progress.progress_percentage, 2)
+        data = [
+            RankProgressChartPoint(
+                label="Progress",
+                value=rank_progress.progress_percentage,
+            ),
+            RankProgressChartPoint(
+                label="Remaining",
+                value=max(remaining_percentage, 0.0),
+            ),
+        ]
+
+    return RankProgressChartSection(
+        is_available=True,
+        unavailable_reason=None,
+        labels=[point.label for point in data],
+        values=[point.value for point in data],
+        data=data,
+        current_rank=rank_progress.current_rank,
+        next_rank=rank_progress.next_rank,
+        current_points=rank_progress.current_points,
+        start_points=rank_progress.current_rank_min_points,
+        target_points=rank_progress.next_rank_min_points,
+        remaining_points=rank_progress.points_to_next_rank,
+        progress_percentage=rank_progress.progress_percentage,
+        is_highest_rank=rank_progress.is_highest_rank,
+    )
+
+
+def build_team_position_chart(
+    team_position: int | None,
+    total_sales_advisors: int | None,
+    unavailable_reason: str | None,
+) -> TeamPositionChartSection:
+    if team_position is None or total_sales_advisors is None:
+        return TeamPositionChartSection(
+            is_available=False,
+            unavailable_reason=unavailable_reason,
+            labels=[],
+            values=[],
+            data=[],
+            team_position=None,
+            total_sales_advisors=None,
+            advisors_ahead=None,
+            advisors_behind=None,
+        )
+
+    advisors_ahead = team_position - 1
+    advisors_behind = total_sales_advisors - team_position
+    data = [
+        TeamPositionChartPoint(
+            label="Advisors ahead",
+            value=float(advisors_ahead),
+        ),
+        TeamPositionChartPoint(
+            label="Current advisor",
+            value=1.0,
+        ),
+        TeamPositionChartPoint(
+            label="Advisors behind",
+            value=float(advisors_behind),
+        ),
+    ]
+
+    return TeamPositionChartSection(
+        is_available=True,
+        unavailable_reason=None,
+        labels=[point.label for point in data],
+        values=[point.value for point in data],
+        data=data,
+        team_position=team_position,
+        total_sales_advisors=total_sales_advisors,
+        advisors_ahead=advisors_ahead,
+        advisors_behind=advisors_behind,
+    )
+
+
+def get_sales_advisor_performance_charts(
+    session: Session,
+    current_user: AppUser,
+) -> SalesAdvisorPerformanceChartsResponse:
+    validate_sales_advisor(current_user)
+
+    current_points = current_user.points or 0
+    transactions = get_completed_sales_transactions_for_advisor(
+        session=session,
+        user_id=current_user.user_id,
+    )
+    personal_performance = build_personal_performance_chart(transactions)
+
+    team_average_points = None
+    team_position = None
+    total_sales_advisors = None
+    team_unavailable_reason = TEAM_DATA_UNAVAILABLE
+
+    if current_user.manager_user_id is not None:
+        team_members = get_sales_advisor_team_members(
+            session=session,
+            manager_user_id=current_user.manager_user_id,
+        )
+        team_members = ensure_current_user_in_team(current_user, team_members)
+        team_comparison = build_team_comparison(current_user, team_members)
+        team_average_points = team_comparison.team_average_points
+        team_position = team_comparison.team_position
+        total_sales_advisors = team_comparison.total_sales_advisors
+        team_unavailable_reason = None
+
+    return SalesAdvisorPerformanceChartsResponse(
+        user_id=current_user.user_id,
+        personal_performance=personal_performance,
+        personal_vs_team_average=build_personal_vs_team_average_chart(
+            current_points=current_points,
+            team_average_points=team_average_points,
+            unavailable_reason=team_unavailable_reason,
+        ),
+        rank_progress=build_rank_progress_chart(current_points),
+        team_position=build_team_position_chart(
+            team_position=team_position,
+            total_sales_advisors=total_sales_advisors,
+            unavailable_reason=team_unavailable_reason,
+        ),
+    )


### PR DESCRIPTION
Adds two Sales Advisor backend features:

## GET /api/sales-advisor/dashboard/charts

- Returns chart-ready data for personal performance, personal vs team average, rank progress, and team position.
- Handles missing optional data with empty chart arrays and unavailable states.
- Enforces authenticated sales_advisor access.

## GET /api/sales-advisor/leaderboard

- Returns sales advisor leaderboard data for team or global scope.
- Supports configurable limit.
- Sorts advisors by points descending and returns ranking positions.
- Always includes the authenticated advisor’s position, with separate current_user data when outside the returned top N.
- Enforces authenticated sales_advisor access.