### PR TITLE
[Backend] Sales Advisor Profile Details

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,9 @@ from app.sales_advisor_dashboard.overview_router import router as sales_advisor_
 from app.sales_advisor_leaderboard.leaderboard_router import (
     router as sales_advisor_leaderboard_router,
 )
+from app.sales_advisor_leaderboard_my_position.my_position_router import (
+    router as sales_advisor_leaderboard_my_position_router,
+)
 from app.sales_advisor_performance_charts.performance_charts_router import (
     router as sales_advisor_performance_charts_router,
 )
@@ -46,6 +49,7 @@ app.include_router(ai_summary_router)
 app.include_router(ai_activity_summary_router)
 app.include_router(sales_advisor_dashboard_router)
 app.include_router(sales_advisor_leaderboard_router)
+app.include_router(sales_advisor_leaderboard_my_position_router)
 app.include_router(sales_advisor_performance_charts_router)
 
 app.include_router(manager_notifications_router)

--- a/backend/app/sales_advisor_leaderboard_my_position/my_position_repository.py
+++ b/backend/app/sales_advisor_leaderboard_my_position/my_position_repository.py
@@ -1,0 +1,21 @@
+from sqlmodel import Session
+
+from app.models.app_user import AppUser
+from app.sales_advisor_leaderboard.leaderboard_repository import (
+    get_global_sales_advisors,
+    get_team_sales_advisors,
+)
+
+
+def get_global_sales_advisors_for_position(session: Session) -> list[AppUser]:
+    return get_global_sales_advisors(session=session)
+
+
+def get_team_sales_advisors_for_position(
+    session: Session,
+    manager_user_id: int | None,
+) -> list[AppUser]:
+    return get_team_sales_advisors(
+        session=session,
+        manager_user_id=manager_user_id,
+    )

--- a/backend/app/sales_advisor_leaderboard_my_position/my_position_router.py
+++ b/backend/app/sales_advisor_leaderboard_my_position/my_position_router.py
@@ -1,0 +1,57 @@
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from sqlmodel import Session
+
+from app.database import get_session
+from app.models.app_user import AppUser
+from app.sales_advisor_leaderboard_my_position.my_position_schemas import (
+    SalesAdvisorLeaderboardMyPositionResponse,
+)
+from app.sales_advisor_leaderboard_my_position.my_position_service import (
+    get_sales_advisor_leaderboard_my_position,
+)
+
+
+def get_current_user_for_my_position(
+    x_user_id: str | None = Header(default=None),
+    session: Session = Depends(get_session),
+) -> AppUser:
+    if x_user_id is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    try:
+        user_id = int(x_user_id)
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid X-User-Id. Use an integer.",
+        )
+
+    user = session.get(AppUser, user_id)
+
+    if user is None:
+        raise HTTPException(status_code=401, detail="Invalid user ID")
+
+    return user
+
+
+router = APIRouter(
+    prefix="/api/sales-advisor/leaderboard",
+    tags=["sales-advisor-leaderboard-my-position"],
+)
+
+
+@router.get(
+    "/my-position",
+    response_model=SalesAdvisorLeaderboardMyPositionResponse,
+    status_code=200,
+)
+def read_sales_advisor_leaderboard_my_position(
+    scope: str = Query(default="team"),
+    session: Session = Depends(get_session),
+    current_user: AppUser = Depends(get_current_user_for_my_position),
+):
+    return get_sales_advisor_leaderboard_my_position(
+        session=session,
+        current_user=current_user,
+        scope=scope,
+    )

--- a/backend/app/sales_advisor_leaderboard_my_position/my_position_schemas.py
+++ b/backend/app/sales_advisor_leaderboard_my_position/my_position_schemas.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class SalesAdvisorLeaderboardMyPositionResponse(BaseModel):
+    position: int
+    total_users: int
+    points: int
+    rank: str

--- a/backend/app/sales_advisor_leaderboard_my_position/my_position_service.py
+++ b/backend/app/sales_advisor_leaderboard_my_position/my_position_service.py
@@ -1,0 +1,48 @@
+from sqlmodel import Session
+
+from app.models.app_user import AppUser
+from app.sales_advisor_dashboard.overview_service import validate_sales_advisor
+from app.sales_advisor_leaderboard.leaderboard_service import (
+    ensure_current_user_in_leaderboard,
+    normalize_leaderboard_scope,
+    sort_advisors_for_ranking,
+)
+from app.sales_advisor_leaderboard_my_position.my_position_repository import (
+    get_global_sales_advisors_for_position,
+    get_team_sales_advisors_for_position,
+)
+from app.sales_advisor_leaderboard_my_position.my_position_schemas import (
+    SalesAdvisorLeaderboardMyPositionResponse,
+)
+
+
+def get_sales_advisor_leaderboard_my_position(
+    session: Session,
+    current_user: AppUser,
+    scope: str,
+) -> SalesAdvisorLeaderboardMyPositionResponse:
+    validate_sales_advisor(current_user)
+    normalized_scope = normalize_leaderboard_scope(scope)
+
+    if normalized_scope == "global":
+        advisors = get_global_sales_advisors_for_position(session=session)
+    else:
+        advisors = get_team_sales_advisors_for_position(
+            session=session,
+            manager_user_id=current_user.manager_user_id,
+        )
+
+    advisors = ensure_current_user_in_leaderboard(current_user, advisors)
+    ranked_advisors = sort_advisors_for_ranking(advisors)
+
+    position_by_user_id = {
+        advisor.user_id: position
+        for position, advisor in enumerate(ranked_advisors, start=1)
+    }
+
+    return SalesAdvisorLeaderboardMyPositionResponse(
+        position=position_by_user_id[current_user.user_id],
+        total_users=len(ranked_advisors),
+        points=current_user.points or 0,
+        rank=current_user.rank,
+    )


### PR DESCRIPTION
## Adds GET `/api/sales-advisor/leaderboard/my-position` in a new backend package: sales_advisor_leaderboard_my_position.

The endpoint returns the authenticated sales advisor’s position, total_users, points, and rank for either team or global scope. It reuses the existing leaderboard ranking rules, so the position stays consistent with the leaderboard overview.

Also includes validation for:

- missing user header: 401
- invalid/non-integer X-User-Id: 400
- non-sales-advisor user: 403
- invalid scope: 400